### PR TITLE
Clean up Terraform syntax/style

### DIFF
--- a/0_foundation/networks.tf
+++ b/0_foundation/networks.tf
@@ -16,64 +16,58 @@
 
 provider "google" {
   version = "~> 2.17.0"
-  project = "${var.project_id}"
+  project = var.project_id
 }
 
 resource "google_compute_network" "anthos-platform" {
   name                    = "anthos-platform"
   auto_create_subnetworks = false
-  depends_on = [
-    "google_project_service.compute"
-  ]
+  depends_on              = [module.project-services.project_id]
 }
 
 resource "google_compute_subnetwork" "anthos-platform-central" {
   name          = "anthos-platform-central"
   ip_cidr_range = "10.2.0.0/16"
   region        = "us-central1"
-  network       = "${google_compute_network.anthos-platform.self_link}"
+  network       = google_compute_network.anthos-platform.self_link
 
-  secondary_ip_range = [
-    {
-      range_name    = "anthos-platform-pods-prod"
-      ip_cidr_range = "172.16.0.0/16"
-    },
-    {
-      range_name    = "anthos-platform-pods-staging"
-      ip_cidr_range = "172.17.0.0/16"
-    },
-    {
-      range_name    = "anthos-platform-pods-dev"
-      ip_cidr_range = "172.18.0.0/16"
-    },
-    {
-      range_name    = "anthos-platform-services-prod"
-      ip_cidr_range = "192.168.0.0/24"
-    },
-    {
-      range_name    = "anthos-platform-services-staging"
-      ip_cidr_range = "192.168.1.0/24"
-    },
-    {
-      range_name    = "anthos-platform-services-dev"
-      ip_cidr_range = "192.168.2.0/24"
-    }
-  ]
+  secondary_ip_range {
+    range_name    = "anthos-platform-pods-prod"
+    ip_cidr_range = "172.16.0.0/16"
+  }
+  secondary_ip_range {
+    range_name    = "anthos-platform-pods-staging"
+    ip_cidr_range = "172.17.0.0/16"
+  }
+  secondary_ip_range {
+    range_name    = "anthos-platform-pods-dev"
+    ip_cidr_range = "172.18.0.0/16"
+  }
+  secondary_ip_range {
+    range_name    = "anthos-platform-services-prod"
+    ip_cidr_range = "192.168.0.0/24"
+  }
+  secondary_ip_range {
+    range_name    = "anthos-platform-services-staging"
+    ip_cidr_range = "192.168.1.0/24"
+  }
+  secondary_ip_range {
+    range_name    = "anthos-platform-services-dev"
+    ip_cidr_range = "192.168.2.0/24"
+  }
 }
 
 resource "google_compute_subnetwork" "anthos-platform-east" {
   name          = "anthos-platform-east"
   ip_cidr_range = "10.3.0.0/16"
   region        = "us-east1"
-  network       = "${google_compute_network.anthos-platform.self_link}"
-  secondary_ip_range = [
-    {
-      range_name    = "anthos-platform-pods-prod"
-      ip_cidr_range = "172.19.0.0/16"
-    },
-    {
-      range_name    = "anthos-platform-services-prod"
-      ip_cidr_range = "192.168.3.0/24"
-    }
-  ]
+  network       = google_compute_network.anthos-platform.self_link
+  secondary_ip_range {
+    range_name    = "anthos-platform-pods-prod"
+    ip_cidr_range = "172.19.0.0/16"
+  }
+  secondary_ip_range {
+    range_name    = "anthos-platform-services-prod"
+    ip_cidr_range = "192.168.3.0/24"
+  }
 }

--- a/0_foundation/services.tf
+++ b/0_foundation/services.tf
@@ -14,38 +14,17 @@
  * limitations under the License.
  */
 
-resource "google_project_service" "compute" {
-  project = var.project_id
-  service = "compute.googleapis.com"
+module "project-services" {
+  source  = "terraform-google-modules/project-factory/google//modules/project_services"
+  version = "~> 8.0"
 
-  disable_dependent_services = true
-  depends_on                 = [google_project_service.cloudresourcemanager]
-}
+  project_id = var.project_id
 
-resource "google_project_service" "container" {
-  project = var.project_id
-  service = "container.googleapis.com"
-
-  disable_dependent_services = true
-}
-
-resource "google_project_service" "cloudresourcemanager" {
-  project = var.project_id
-  service = "cloudresourcemanager.googleapis.com"
-
-  disable_dependent_services = true
-}
-
-resource "google_project_service" "sqladmin" {
-  project = var.project_id
-  service = "sqladmin.googleapis.com"
-
-  disable_dependent_services = true
-}
-
-resource "google_project_service" "artifactregistry" {
-  project = var.project_id
-  service = "artifactregistry.googleapis.com"
-
-  disable_dependent_services = true
+  activate_apis = [
+    "compute.googleapis.com",
+    "container.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "sqladmin.googleapis.com",
+    "artifactregistry.googleapis.com"
+  ]
 }

--- a/0_foundation/services.tf
+++ b/0_foundation/services.tf
@@ -15,38 +15,37 @@
  */
 
 resource "google_project_service" "compute" {
-  project = "${var.project_id}"
+  project = var.project_id
   service = "compute.googleapis.com"
 
   disable_dependent_services = true
-  depends_on = ["google_project_service.cloudresourcemanager"]
+  depends_on                 = [google_project_service.cloudresourcemanager]
 }
 
 resource "google_project_service" "container" {
-  project = "${var.project_id}"
+  project = var.project_id
   service = "container.googleapis.com"
 
   disable_dependent_services = true
 }
 
 resource "google_project_service" "cloudresourcemanager" {
-  project = "${var.project_id}"
+  project = var.project_id
   service = "cloudresourcemanager.googleapis.com"
 
   disable_dependent_services = true
 }
 
 resource "google_project_service" "sqladmin" {
-  project = "${var.project_id}"
+  project = var.project_id
   service = "sqladmin.googleapis.com"
 
   disable_dependent_services = true
 }
 
 resource "google_project_service" "artifactregistry" {
-  project = "${var.project_id}"
+  project = var.project_id
   service = "artifactregistry.googleapis.com"
 
   disable_dependent_services = true
 }
-

--- a/0_foundation/versions.tf
+++ b/0_foundation/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/1_clusters/clusters.tf
+++ b/1_clusters/clusters.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  project = "${var.project_id}"
+  project = var.project_id
   version = "~> 3.13"
 }
 
 provider "google-beta" {
-  project = "${var.project_id}"
+  project = var.project_id
   version = "~> 3.13"
 }
 
@@ -44,44 +44,44 @@ data "google_compute_subnetwork" "anthos-platform-east" {
 
 module "anthos-platform-dev" {
   source            = "./modules/anthos-platform-cluster"
-  project_id        = "${var.project_id}"
+  project_id        = var.project_id
   name              = "dev-us-central1"
   region            = "us-central1"
-  network           = "${data.google_compute_network.anthos-platform.name}"
-  subnetwork        = "${data.google_compute_subnetwork.anthos-platform-central.name}"
+  network           = data.google_compute_network.anthos-platform.name
+  subnetwork        = data.google_compute_subnetwork.anthos-platform-central.name
   ip_range_pods     = "anthos-platform-pods-dev"
   ip_range_services = "anthos-platform-services-dev"
 }
 
 module "anthos-platform-staging" {
   source            = "./modules/anthos-platform-cluster"
-  project_id        = "${var.project_id}"
+  project_id        = var.project_id
   name              = "staging-us-central1"
   region            = "us-central1"
-  network           = "${data.google_compute_network.anthos-platform.name}"
-  subnetwork        = "${data.google_compute_subnetwork.anthos-platform-central.name}"
+  network           = data.google_compute_network.anthos-platform.name
+  subnetwork        = data.google_compute_subnetwork.anthos-platform-central.name
   ip_range_pods     = "anthos-platform-pods-staging"
   ip_range_services = "anthos-platform-services-staging"
 }
 
 module "anthos-platform-prod-central" {
   source            = "./modules/anthos-platform-cluster"
-  project_id        = "${var.project_id}"
+  project_id        = var.project_id
   name              = "prod-us-central1"
   region            = "us-central1"
-  network           = "${data.google_compute_network.anthos-platform.name}"
-  subnetwork        = "${data.google_compute_subnetwork.anthos-platform-central.name}"
+  network           = data.google_compute_network.anthos-platform.name
+  subnetwork        = data.google_compute_subnetwork.anthos-platform-central.name
   ip_range_pods     = "anthos-platform-pods-prod"
   ip_range_services = "anthos-platform-services-prod"
 }
 
 module "anthos-platform-prod-east" {
   source            = "./modules/anthos-platform-cluster"
-  project_id        = "${var.project_id}"
+  project_id        = var.project_id
   name              = "prod-us-east1"
   region            = "us-east1"
-  network           = "${data.google_compute_network.anthos-platform.name}"
-  subnetwork        = "${data.google_compute_subnetwork.anthos-platform-east.name}"
+  network           = data.google_compute_network.anthos-platform.name
+  subnetwork        = data.google_compute_subnetwork.anthos-platform-east.name
   ip_range_pods     = "anthos-platform-pods-prod"
   ip_range_services = "anthos-platform-services-prod"
 }

--- a/1_clusters/modules/anthos-platform-cluster/main.tf
+++ b/1_clusters/modules/anthos-platform-cluster/main.tf
@@ -15,49 +15,49 @@
  */
 
 resource "google_service_account" "service_account" {
-  project      = "${var.project_id}"
+  project      = var.project_id
   account_id   = "tf-sa-${var.name}"
   display_name = "Cluster Service Account for ${var.name}"
 }
 
 resource "google_project_iam_member" "cluster_iam_logginglogwriter" {
-  project = "${var.project_id}"
+  project = var.project_id
   role    = "roles/logging.logWriter"
   member  = "serviceAccount:${google_service_account.service_account.email}"
 }
 
 resource "google_project_iam_member" "cluster_iam_monitoringmetricwriter" {
-  project = "${var.project_id}"
+  project = var.project_id
   role    = "roles/monitoring.metricWriter"
   member  = "serviceAccount:${google_service_account.service_account.email}"
 }
 
 resource "google_project_iam_member" "cluster_iam_monitoringviewer" {
-  project = "${var.project_id}"
+  project = var.project_id
   role    = "roles/monitoring.viewer"
   member  = "serviceAccount:${google_service_account.service_account.email}"
 }
 
 resource "google_project_iam_member" "cluster_iam_artifactregistryreader" {
-  project = "${var.project_id}"
+  project = var.project_id
   role    = "roles/artifactregistry.reader"
   member  = "serviceAccount:${google_service_account.service_account.email}"
 }
 
 module "anthos_platform_cluster" {
   source             = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-public-cluster?ref=v7.3.0"
-  project_id         = "${var.project_id}"
-  name               = "${var.name}"
-  region             = "${var.region}"
-  network            = "${var.network}"
-  subnetwork         = "${var.subnetwork}"
-  ip_range_pods      = "${var.ip_range_pods}"
-  ip_range_services  = "${var.ip_range_services}"
-  kubernetes_version = "${var.gke_kubernetes_version}"
+  project_id         = var.project_id
+  name               = var.name
+  region             = var.region
+  network            = var.network
+  subnetwork         = var.subnetwork
+  ip_range_pods      = var.ip_range_pods
+  ip_range_services  = var.ip_range_services
+  kubernetes_version = var.gke_kubernetes_version
   regional           = true
 
   create_service_account = false
-  service_account        = "${google_service_account.service_account.email}"
+  service_account        = google_service_account.service_account.email
   identity_namespace     = "${var.project_id}.svc.id.goog"
   node_metadata          = "GKE_METADATA_SERVER"
 
@@ -66,10 +66,11 @@ module "anthos_platform_cluster" {
   node_pools = [
     {
       name         = "wi-pool"
-      machine_type = "${var.machine_type}"
-      min_count    = "${var.minimum_node_pool_instances}"
-      max_count    = "${var.maximum_node_pool_instances}"
+      machine_type = var.machine_type
+      min_count    = var.minimum_node_pool_instances
+      max_count    = var.maximum_node_pool_instances
       auto_upgrade = true
-    }
+    },
   ]
 }
+

--- a/1_clusters/modules/anthos-platform-cluster/main.tf
+++ b/1_clusters/modules/anthos-platform-cluster/main.tf
@@ -45,7 +45,8 @@ resource "google_project_iam_member" "cluster_iam_artifactregistryreader" {
 }
 
 module "anthos_platform_cluster" {
-  source             = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-public-cluster?ref=v7.3.0"
+  source             = "terraform-google-modules/kubernetes-engine/google//modules/beta-public-cluster"
+  version            = "~> 7.3.0"
   project_id         = var.project_id
   name               = var.name
   region             = var.region

--- a/1_clusters/outputs.tf
+++ b/1_clusters/outputs.tf
@@ -15,21 +15,21 @@
  */
 
 output "development__cluster-service-account" {
-  value       = "${module.anthos-platform-dev.service_account}"
+  value       = module.anthos-platform-dev.service_account
   description = "Service account used to create the cluster and node pool(s)"
 }
 
 output "staging__cluster-service-account" {
-  value       = "${module.anthos-platform-staging.service_account}"
+  value       = module.anthos-platform-staging.service_account
   description = "Service account used to create the cluster and node pool(s)"
 }
 
 output "prod-east__cluster-service-account" {
-  value       = "${module.anthos-platform-prod-east.service_account}"
+  value       = module.anthos-platform-prod-east.service_account
   description = "Service account used to create the cluster and node pool(s)"
 }
 
 output "prod-central__cluster-service-account" {
-  value       = "${module.anthos-platform-prod-central.service_account}"
+  value       = module.anthos-platform-prod-central.service_account
   description = "Service account used to create the cluster and node pool(s)"
 }

--- a/1_clusters/versions.tf
+++ b/1_clusters/versions.tf
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-output "service_account" {
-  value       = module.anthos_platform_cluster.service_account
-  description = "Service account used to create the cluster and node pool(s)"
+terraform {
+  required_version = ">= 0.12"
 }
-

--- a/2_gitlab/gitlab-repos/repos.tf
+++ b/2_gitlab/gitlab-repos/repos.tf
@@ -15,9 +15,9 @@
  */
 
 provider "gitlab" {
-    token = "${var.gitlab_token}"
-    base_url = "https://${var.gitlab_hostname}/api/v4/"
-    insecure = true
+  token    = var.gitlab_token
+  base_url = "https://${var.gitlab_hostname}/api/v4/"
+  insecure = true
 }
 
 locals {
@@ -25,172 +25,173 @@ locals {
 }
 
 resource "gitlab_group" "platform-admins" {
-  name        = "platform-admins"
-  path        = "platform-admins"
-  description = "An group of projects for Platform Admins"
+  name             = "platform-admins"
+  path             = "platform-admins"
+  description      = "An group of projects for Platform Admins"
   visibility_level = "internal"
 }
 
 resource "gitlab_project" "anthos-config-management" {
-  name         = "anthos-config-management"
-  description  = "Anthos Config Management repo"
-  namespace_id = "${gitlab_group.platform-admins.id}"
+  name             = "anthos-config-management"
+  description      = "Anthos Config Management repo"
+  namespace_id     = gitlab_group.platform-admins.id
   visibility_level = "internal"
-  default_branch = "master"
+  default_branch   = "master"
 }
 
 resource "gitlab_project" "shared-kustomize-bases" {
-  name         = "shared-kustomize-bases"
-  description  = "Kubernetes Application Configuration Bases"
-  namespace_id = "${gitlab_group.platform-admins.id}"
+  name             = "shared-kustomize-bases"
+  description      = "Kubernetes Application Configuration Bases"
+  namespace_id     = gitlab_group.platform-admins.id
   visibility_level = "internal"
-  default_branch = "master"
+  default_branch   = "master"
 }
 
 resource "gitlab_project" "kaniko-docker" {
-  name         = "kaniko-docker"
-  description  = "Docker+Kaniko Docker image"
-  namespace_id = "${gitlab_group.platform-admins.id}"
+  name             = "kaniko-docker"
+  description      = "Docker+Kaniko Docker image"
+  namespace_id     = gitlab_group.platform-admins.id
   visibility_level = "internal"
-  default_branch = "master"
+  default_branch   = "master"
 }
 
 resource "gitlab_project" "kustomize-docker" {
-  name         = "kustomize-docker"
-  description  = "Kustomize Docker image"
-  namespace_id = "${gitlab_group.platform-admins.id}"
+  name             = "kustomize-docker"
+  description      = "Kustomize Docker image"
+  namespace_id     = gitlab_group.platform-admins.id
   visibility_level = "internal"
-  default_branch = "master"
+  default_branch   = "master"
 }
 
 resource "gitlab_project" "shared-ci-cd" {
-  name         = "shared-ci-cd"
-  description  = "Shared CI/CD configurations"
-  namespace_id = "${gitlab_group.platform-admins.id}"
+  name             = "shared-ci-cd"
+  description      = "Shared CI/CD configurations"
+  namespace_id     = gitlab_group.platform-admins.id
   visibility_level = "internal"
-  default_branch = "master"
+  default_branch   = "master"
 }
 
 resource "gitlab_project" "golang-template" {
-  name         = "golang-template"
-  description  = "Template for new Go applications"
-  namespace_id = "${gitlab_group.platform-admins.id}"
+  name             = "golang-template"
+  description      = "Template for new Go applications"
+  namespace_id     = gitlab_group.platform-admins.id
   visibility_level = "internal"
-  default_branch = "master"
+  default_branch   = "master"
 }
 
 resource "gitlab_project" "golang-template-env" {
-  name         = "golang-template-env"
-  description  = "Template for new Go app environment repos"
-  namespace_id = "${gitlab_group.platform-admins.id}"
+  name             = "golang-template-env"
+  description      = "Template for new Go app environment repos"
+  namespace_id     = gitlab_group.platform-admins.id
   visibility_level = "internal"
-  default_branch = "master"
+  default_branch   = "master"
 }
 
 resource "gitlab_project" "java-template" {
-  name         = "java-template"
-  description  = "Template for new Java applications"
-  namespace_id = "${gitlab_group.platform-admins.id}"
+  name             = "java-template"
+  description      = "Template for new Java applications"
+  namespace_id     = gitlab_group.platform-admins.id
   visibility_level = "internal"
-  default_branch = "master"
+  default_branch   = "master"
 }
 
 resource "gitlab_project" "java-template-env" {
-  name         = "java-template-env"
-  description  = "Template for new Java app environment repos"
-  namespace_id = "${gitlab_group.platform-admins.id}"
+  name             = "java-template-env"
+  description      = "Template for new Java app environment repos"
+  namespace_id     = gitlab_group.platform-admins.id
   visibility_level = "internal"
-  default_branch = "master"
+  default_branch   = "master"
 }
 
 resource "gitlab_deploy_key" "acm-staging-us-central1" {
-  project = "platform-admins/anthos-config-management"
-  title   = "Staging deploy key"
-  key     = "${file("${local.ssh-key-path}/staging-us-central1.pub")}"
-  depends_on = ["gitlab_project.anthos-config-management"]
+  project    = "platform-admins/anthos-config-management"
+  title      = "Staging deploy key"
+  key        = file("${local.ssh-key-path}/staging-us-central1.pub")
+  depends_on = [gitlab_project.anthos-config-management]
 }
 
 resource "gitlab_deploy_key" "acm-prod-us-central1" {
-  project = "platform-admins/anthos-config-management"
-  title   = "Production us-central1 deploy key"
-  key     = "${file("${local.ssh-key-path}/prod-us-central1.pub")}"
-  depends_on = ["gitlab_project.anthos-config-management"]
+  project    = "platform-admins/anthos-config-management"
+  title      = "Production us-central1 deploy key"
+  key        = file("${local.ssh-key-path}/prod-us-central1.pub")
+  depends_on = [gitlab_project.anthos-config-management]
 }
+
 resource "gitlab_deploy_key" "acm-prod-us-east1" {
-  project = "platform-admins/anthos-config-management"
-  title   = "Production East deploy key"
-  key     = "${file("${local.ssh-key-path}/prod-us-east1.pub")}"
-  depends_on = ["gitlab_project.anthos-config-management"]
+  project    = "platform-admins/anthos-config-management"
+  title      = "Production East deploy key"
+  key        = file("${local.ssh-key-path}/prod-us-east1.pub")
+  depends_on = [gitlab_project.anthos-config-management]
 }
 
 resource "gitlab_deploy_key" "local-user-kaniko-docker-push" {
-  project = "platform-admins/kaniko-docker"
-  title   = "Local User deploy key"
-  key     = "${file("${local.ssh-key-path}/kaniko-docker.pub")}"
-  can_push = true
-  depends_on = ["gitlab_project.kaniko-docker"]
+  project    = "platform-admins/kaniko-docker"
+  title      = "Local User deploy key"
+  key        = file("${local.ssh-key-path}/kaniko-docker.pub")
+  can_push   = true
+  depends_on = [gitlab_project.kaniko-docker]
 }
 
 resource "gitlab_deploy_key" "local-user-kustomize-docker-push" {
-  project = "platform-admins/kustomize-docker"
-  title   = "Local User deploy key"
-  key     = "${file("${local.ssh-key-path}/kustomize-docker.pub")}"
-  can_push = true
-  depends_on = ["gitlab_project.kustomize-docker"]
+  project    = "platform-admins/kustomize-docker"
+  title      = "Local User deploy key"
+  key        = file("${local.ssh-key-path}/kustomize-docker.pub")
+  can_push   = true
+  depends_on = [gitlab_project.kustomize-docker]
 }
 
 resource "gitlab_deploy_key" "local-user-acm-push" {
-  project = "platform-admins/anthos-config-management"
-  title   = "Local User deploy key"
-  key     = "${file("${local.ssh-key-path}/anthos-config-management.pub")}"
-  can_push = true
-  depends_on = ["gitlab_project.anthos-config-management"]
+  project    = "platform-admins/anthos-config-management"
+  title      = "Local User deploy key"
+  key        = file("${local.ssh-key-path}/anthos-config-management.pub")
+  can_push   = true
+  depends_on = [gitlab_project.anthos-config-management]
 }
 
 resource "gitlab_deploy_key" "local-user-kustomize-push" {
-  project = "platform-admins/shared-kustomize-bases"
-  title   = "Local User deploy key"
-  key     = "${file("${local.ssh-key-path}/shared-kustomize-bases.pub")}"
-  depends_on = ["gitlab_project.shared-kustomize-bases"]
-  can_push = true
+  project    = "platform-admins/shared-kustomize-bases"
+  title      = "Local User deploy key"
+  key        = file("${local.ssh-key-path}/shared-kustomize-bases.pub")
+  depends_on = [gitlab_project.shared-kustomize-bases]
+  can_push   = true
 }
 
 resource "gitlab_deploy_key" "local-user-ci-cd-push" {
-  project = "platform-admins/shared-ci-cd"
-  title   = "Local User deploy key"
-  key     = "${file("${local.ssh-key-path}/shared-ci-cd.pub")}"
-  depends_on = ["gitlab_project.shared-ci-cd"]
-  can_push = true
+  project    = "platform-admins/shared-ci-cd"
+  title      = "Local User deploy key"
+  key        = file("${local.ssh-key-path}/shared-ci-cd.pub")
+  depends_on = [gitlab_project.shared-ci-cd]
+  can_push   = true
 }
 
 resource "gitlab_deploy_key" "local-user-golang-template-push" {
-  project = "platform-admins/golang-template"
-  title   = "Local User deploy key"
-  key     = "${file("${local.ssh-key-path}/golang-template.pub")}"
-  depends_on = ["gitlab_project.golang-template"]
-  can_push = true
+  project    = "platform-admins/golang-template"
+  title      = "Local User deploy key"
+  key        = file("${local.ssh-key-path}/golang-template.pub")
+  depends_on = [gitlab_project.golang-template]
+  can_push   = true
 }
 
 resource "gitlab_deploy_key" "local-user-golang-template-env-push" {
-  project = "platform-admins/golang-template-env"
-  title   = "Local User deploy key"
-  key     = "${file("${local.ssh-key-path}/golang-template-env.pub")}"
-  depends_on = ["gitlab_project.golang-template-env"]
-  can_push = true
+  project    = "platform-admins/golang-template-env"
+  title      = "Local User deploy key"
+  key        = file("${local.ssh-key-path}/golang-template-env.pub")
+  depends_on = [gitlab_project.golang-template-env]
+  can_push   = true
 }
 
 resource "gitlab_deploy_key" "local-user-java-template-push" {
-  project = "platform-admins/java-template"
-  title   = "Local User deploy key"
-  key     = "${file("${local.ssh-key-path}/java-template.pub")}"
-  depends_on = ["gitlab_project.java-template"]
-  can_push = true
+  project    = "platform-admins/java-template"
+  title      = "Local User deploy key"
+  key        = file("${local.ssh-key-path}/java-template.pub")
+  depends_on = [gitlab_project.java-template]
+  can_push   = true
 }
 
 resource "gitlab_deploy_key" "local-user-java-template-env-push" {
-  project = "platform-admins/java-template-env"
-  title   = "Local User deploy key"
-  key     = "${file("${local.ssh-key-path}/java-template-env.pub")}"
-  depends_on = ["gitlab_project.java-template-env"]
-  can_push = true
+  project    = "platform-admins/java-template-env"
+  title      = "Local User deploy key"
+  key        = file("${local.ssh-key-path}/java-template-env.pub")
+  depends_on = [gitlab_project.java-template-env]
+  can_push   = true
 }

--- a/2_gitlab/gitlab.tf
+++ b/2_gitlab/gitlab.tf
@@ -15,19 +15,19 @@
  */
 
 module "gke-gitlab" {
-  source            = "github.com/terraform-google-modules/terraform-google-gke-gitlab?ref=master"
-  project_id        = "${var.project_id}"
-  domain            = "${var.domain}"
-  certmanager_email = "no-reply@${var.project_id}.example.com"
-  gitlab_address_name = "gitlab"
+  source                = "github.com/terraform-google-modules/terraform-google-gke-gitlab?ref=master"
+  project_id            = var.project_id
+  domain                = var.domain
+  certmanager_email     = "no-reply@${var.project_id}.example.com"
+  gitlab_address_name   = "gitlab"
   gitlab_runner_install = true
-  gitlab_db_name    = "gitlab-${lower(random_id.database_id.hex)}"
+  gitlab_db_name        = "gitlab-${lower(random_id.database_id.hex)}"
 }
 
 data "google_compute_address" "gitlab" {
-  project       = "${var.project_id}"
-  region        = "us-central1"
-  name          = "gitlab"
+  project = var.project_id
+  region  = "us-central1"
+  name    = "gitlab"
 }
 
 resource "random_id" "database_id" {

--- a/2_gitlab/outputs.tf
+++ b/2_gitlab/outputs.tf
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-
 output "gitlab_address" {
-  value       = "${data.google_compute_address.gitlab.address}"
+  value       = data.google_compute_address.gitlab.address
   description = "Point your wildcard domain to this IP address as an A record"
 }
 
 output "gitlab_domain" {
-  value       = "${var.domain}"
+  value       = var.domain
   description = "Domain used to deploy Gitlab."
 }


### PR DESCRIPTION
This updates the syntax for foundation and clusters to match 0.12 syntax and style. I also added registry-based version pinning for the GKE module.