### PR TITLE
Adding non-authoritative binary authorization infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ terraform.tfstate*
 
 .vscode/
 target/
+
+.envrc

--- a/1_clusters/binary-auth.tf
+++ b/1_clusters/binary-auth.tf
@@ -1,0 +1,108 @@
+resource "random_pet" "keyring-name" {
+}
+
+resource "google_kms_key_ring" "keyring" {
+  name     = "attestor-key-ring-${random_pet.keyring-name.id}"
+  location = var.keyring-region
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+locals {
+    attestors = [
+        # Note: module for_each support coming soon
+        "quality",
+        "build",
+        "security"
+    ]
+  admin_enabled_apis = [
+    "compute.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "iam.googleapis.com",
+    "containeranalysis.googleapis.com",
+    "binaryauthorization.googleapis.com",
+    "container.googleapis.com",
+    "cloudkms.googleapis.com",
+    "secretmanager.googleapis.com"
+  ]
+
+}
+
+# APIs required for Binary Authorization
+resource "google_project_service" "enabled-apis" {
+  for_each                   = toset(local.admin_enabled_apis)
+  project                    = var.project_id
+  service                    = each.value
+  disable_dependent_services = true
+  disable_on_destroy         = true
+}
+
+
+# Create Quality Assurance attestor
+module "quality-attestor" {
+  source = "./modules/binary-authorization"
+
+  attestor-name = local.attestors[0]
+  keyring-id    = google_kms_key_ring.keyring.id
+}
+
+# Create Builder attestor
+module "build-attestor" {
+  source = "./modules/binary-authorization"
+
+  attestor-name = local.attestors[1]
+  keyring-id    = google_kms_key_ring.keyring.id
+}
+
+# Create Security attestor
+module "security-attestor" {
+  source = "./modules/binary-authorization"
+
+  attestor-name = local.attestors[2]
+  keyring-id    = google_kms_key_ring.keyring.id
+}
+
+resource "google_binary_authorization_policy" "policy" {
+  admission_whitelist_patterns {
+      # TODO: Figure out pattern for Gitlab's repo
+    name_pattern = "quay.io/random-containers/*"
+  }
+
+  admission_whitelist_patterns {
+    name_pattern = "gcr.io/${var.project_id}/*" # Pushes to GCR for project
+  }
+
+  global_policy_evaluation_mode = "ENABLE"
+
+  # Production ready (all attestors required)
+  default_admission_rule {
+    evaluation_mode  = "REQUIRE_ATTESTATION"
+    enforcement_mode = "DRYRUN_AUDIT_LOG_ONLY"
+    require_attestations_by = [
+      module.quality-attestor.attestor,
+      module.build-attestor.attestor,
+      module.security-attestor.attestor
+    ]
+  }
+  # Stage Environment Needs Build and Security
+  cluster_admission_rules {
+    cluster          = "${module.anthos-platform-staging.region}.${module.anthos-platform-staging.cluster-name}"
+    evaluation_mode  = "REQUIRE_ATTESTATION"
+    enforcement_mode = "DRYRUN_AUDIT_LOG_ONLY"
+    require_attestations_by = [
+      module.build-attestor.attestor,
+      module.security-attestor.attestor
+    ]
+  }
+  # Development Environment, Build Quality Attestion only, non-authorative
+  cluster_admission_rules {
+    cluster          = "${module.anthos-platform-dev.region}.${module.anthos-platform-dev.cluster-name}"
+    evaluation_mode  = "REQUIRE_ATTESTATION"
+    enforcement_mode = "DRYRUN_AUDIT_LOG_ONLY"
+    require_attestations_by = [
+      module.build-attestor.attestor
+    ]
+  }
+
+}

--- a/1_clusters/binary-auth.tf
+++ b/1_clusters/binary-auth.tf
@@ -30,14 +30,14 @@ locals {
 }
 
 # APIs required for Binary Authorization
-resource "google_project_service" "enabled-apis" {
-  for_each                   = toset(local.admin_enabled_apis)
-  project                    = var.project_id
-  service                    = each.value
-  disable_dependent_services = true
-  disable_on_destroy         = true
-}
+module "project-services" {
+  source  = "terraform-google-modules/project-factory/google//modules/project_services"
+  version = "~> 8.0"
 
+  project_id = var.project_id
+
+  activate_apis = local.admin_enabled_apis
+}
 
 # Create Quality Assurance attestor
 module "quality-attestor" {

--- a/1_clusters/modules/anthos-platform-cluster/main.tf
+++ b/1_clusters/modules/anthos-platform-cluster/main.tf
@@ -57,6 +57,8 @@ module "anthos_platform_cluster" {
   kubernetes_version = var.gke_kubernetes_version
   regional           = true
 
+  enable_binary_authorization = true
+
   create_service_account = false
   service_account        = google_service_account.service_account.email
   identity_namespace     = "${var.project_id}.svc.id.goog"

--- a/1_clusters/modules/anthos-platform-cluster/outputs.tf
+++ b/1_clusters/modules/anthos-platform-cluster/outputs.tf
@@ -19,3 +19,12 @@ output "service_account" {
   description = "Service account used to create the cluster and node pool(s)"
 }
 
+output "region" {
+  value       = var.region
+  description = "Region for development cluster"
+}
+
+output "cluster-name" {
+  value       = var.name
+  description = "Cluster Name"
+}

--- a/1_clusters/modules/binary-authorization/main.tf
+++ b/1_clusters/modules/binary-authorization/main.tf
@@ -1,0 +1,43 @@
+
+resource "google_binary_authorization_attestor" "attestor" {
+  name = "${var.attestor-name}-attestor"
+  attestation_authority_note {
+    note_reference = google_container_analysis_note.build-note.name
+    public_keys {
+      id = data.google_kms_crypto_key_version.version.id
+      pkix_public_key {
+        public_key_pem      = data.google_kms_crypto_key_version.version.public_key[0].pem
+        signature_algorithm = data.google_kms_crypto_key_version.version.public_key[0].algorithm
+      }
+    }
+  }
+}
+
+resource "google_container_analysis_note" "build-note" {
+  name = "${var.attestor-name}-attestor-note"
+  attestation_authority {
+    hint {
+      human_readable_name = "${var.attestor-name} Attestor"
+    }
+  }
+}
+
+# Key Creation (one per attestor) 
+
+data "google_kms_crypto_key_version" "version" {
+  crypto_key = google_kms_crypto_key.crypto-key.id
+}
+
+resource "google_kms_crypto_key" "crypto-key" {
+  name     = "${var.attestor-name}-attestor-key"
+  key_ring = var.keyring-id
+  purpose  = "ASYMMETRIC_SIGN"
+
+  version_template {
+    algorithm = "RSA_SIGN_PKCS1_4096_SHA512"
+  }
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}

--- a/1_clusters/modules/binary-authorization/outputs.tf
+++ b/1_clusters/modules/binary-authorization/outputs.tf
@@ -1,0 +1,10 @@
+output key {
+  value       = google_kms_crypto_key.crypto-key.name
+  description = "Name of the Key created for the attestor"
+}
+
+output attestor {
+  value       = google_binary_authorization_attestor.attestor.name
+  description = "Name of the built attestor"
+}
+

--- a/1_clusters/modules/binary-authorization/variables.tf
+++ b/1_clusters/modules/binary-authorization/variables.tf
@@ -1,0 +1,9 @@
+variable attestor-name {
+  type        = string
+  description = "Name of the attestor"
+}
+
+variable keyring-id {
+  type        = string
+  description = "Keyring ID for attestor keys"
+}

--- a/1_clusters/terraform.tfvars
+++ b/1_clusters/terraform.tfvars
@@ -1,1 +1,1 @@
-project_id = "YOUR_PROJECT_ID"
+project_id = "binary-authorization"

--- a/1_clusters/terraform.tfvars
+++ b/1_clusters/terraform.tfvars
@@ -1,1 +1,1 @@
-project_id = "binary-authorization"
+project_id = "YOUR_PROJECT_ID"

--- a/1_clusters/variables.tf
+++ b/1_clusters/variables.tf
@@ -17,3 +17,9 @@
 variable "project_id" {
   description = "The project ID to host the cluster in"
 }
+
+variable keyring-region {
+  type        = string
+  default     = "us-central1"
+  description = "Region used for key-ring"
+}

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Within GitLab you will have the following repo structure:
     gcloud services enable cloudbuild.googleapis.com
     gcloud services enable serviceusage.googleapis.com
     gcloud projects add-iam-policy-binding ${PROJECT_ID} --member serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com   --role roles/owner
+    gcloud projects add-iam-policy-binding ${PROJECT_ID} --member serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com --role roles/containeranalysis.admin
     ```
 
 1. Provision the address that GitLab will use.

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -25,6 +25,7 @@ gcloud config set project ${PROJECT_ID}
 export PROJECT_NUMBER=$(gcloud projects describe ${PROJECT_ID} --format 'value(projectNumber)')
 gcloud services enable cloudbuild.googleapis.com
 gcloud projects add-iam-policy-binding ${PROJECT_ID} --member serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com   --role roles/owner
+gcloud projects add-iam-policy-binding ${PROJECT_ID} --member serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com --role roles/containeranalysis.admin
 
 # Allocate GitLab Address
 gcloud services enable compute.googleapis.com


### PR DESCRIPTION
Creating the infrastructure for each of the clusters to accept/use GCP binary authorization. All policies added are in the DRY-RUN state, so policy violating events are logged and allowed to continue.

This push includes 3 Attestors/Actors, Build, Quality and Security.  Future additions will include the ability for each of the attestors to create attestations within the CICD pipeline