### PR TITLE
Changed hipster-loadgenerator dependency 'werkzeug' to v1.0.1

### DIFF
--- a/starter-repos/hipster-loadgenerator/requirements.txt
+++ b/starter-repos/hipster-loadgenerator/requirements.txt
@@ -20,4 +20,4 @@ pyzmq==17.0.0             # via locustio
 requests==2.21.0          # via locustio
 six==1.12.0               # via locustio
 urllib3==1.24.1           # via requests
-werkzeug==0.14.1          # via flask
+werkzeug==1.0.1         # via flask


### PR DESCRIPTION
@viglesiasce Dependabot wanted to bump hipster-loadgenerator's 'werkzeug' dependency version to 0.15.4, but I got an error in deployment, so I tested the latest 'werkzeug' version of 1.0.1 and deployment was successful. We can close PR #17 and merge this PR instead.