### PR TITLE
Adding binary authorization baseline functionality to all clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ terraform.tfstate*
 
 .vscode/
 target/
+
+.envrc
+projects/

--- a/1_clusters/binary-auth.tf
+++ b/1_clusters/binary-auth.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 resource "random_pet" "keyring-name" {
 }
 

--- a/1_clusters/binary-auth.tf
+++ b/1_clusters/binary-auth.tf
@@ -1,0 +1,118 @@
+resource "random_pet" "keyring-name" {
+}
+
+resource "null_resource" "resource-to-wait-on" {
+  provisioner "local-exec" {
+    command = "sleep 60" # one minute to allow eventual consistency of APIs avoiding failures downstream
+  }
+  depends_on = [module.project-services]
+}
+
+resource "google_kms_key_ring" "keyring" {
+  name     = "attestor-key-ring-${random_pet.keyring-name.id}"
+  location = var.keyring-region
+  lifecycle {
+    prevent_destroy = false
+  }
+  depends_on = [null_resource.resource-to-wait-on]
+}
+
+locals {
+    attestors = [
+        # Note: module for_each support coming soon
+        "quality",
+        "build",
+        "security"
+    ]
+  admin_enabled_apis = [
+    "containeranalysis.googleapis.com",
+    "binaryauthorization.googleapis.com",
+    "cloudkms.googleapis.com",
+    "secretmanager.googleapis.com"
+  ]
+
+}
+
+# APIs required for Binary Authorization
+module "project-services" {
+  source  = "terraform-google-modules/project-factory/google//modules/project_services"
+  version = "~> 8.0"
+
+  project_id = var.project_id
+
+  activate_apis = local.admin_enabled_apis
+}
+
+# Create Quality Assurance attestor
+module "quality-attestor" {
+  source = "terraform-google-modules/kubernetes-engine/google//modules/binary-authorization"
+
+project_id = var.project_id
+
+  attestor-name = local.attestors[0]
+  keyring-id    = google_kms_key_ring.keyring.id
+}
+
+# Create Builder attestor
+module "build-attestor" {
+  source = "terraform-google-modules/kubernetes-engine/google//modules/binary-authorization"
+
+project_id = var.project_id
+
+  attestor-name = local.attestors[1]
+  keyring-id    = google_kms_key_ring.keyring.id
+}
+
+# Create Security attestor
+module "security-attestor" {
+  source = "terraform-google-modules/kubernetes-engine/google//modules/binary-authorization"
+
+project_id = var.project_id
+
+  attestor-name = local.attestors[2]
+  keyring-id    = google_kms_key_ring.keyring.id
+}
+
+resource "google_binary_authorization_policy" "policy" {
+  admission_whitelist_patterns {
+      # TODO: Figure out pattern for Gitlab's repo
+    name_pattern = "quay.io/random-containers/*"
+  }
+
+  admission_whitelist_patterns {
+    name_pattern = "gcr.io/${var.project_id}/*" # Pushes to GCR for project
+  }
+
+  global_policy_evaluation_mode = "ENABLE"
+
+  # Production ready (all attestors required)
+  default_admission_rule {
+    evaluation_mode  = "REQUIRE_ATTESTATION"
+    enforcement_mode = "DRYRUN_AUDIT_LOG_ONLY"
+    require_attestations_by = [
+      module.quality-attestor.attestor,
+      module.build-attestor.attestor,
+      module.security-attestor.attestor
+    ]
+  }
+  # Stage Environment Needs Build and Security
+  cluster_admission_rules {
+    cluster          = "${module.anthos-platform-staging.region}.${module.anthos-platform-staging.cluster-name}"
+    evaluation_mode  = "REQUIRE_ATTESTATION"
+    enforcement_mode = "DRYRUN_AUDIT_LOG_ONLY"
+    require_attestations_by = [
+      module.build-attestor.attestor,
+      module.security-attestor.attestor
+    ]
+  }
+  # Development Environment, Build Quality Attestion only, non-authorative
+  cluster_admission_rules {
+    cluster          = "${module.anthos-platform-dev.region}.${module.anthos-platform-dev.cluster-name}"
+    evaluation_mode  = "REQUIRE_ATTESTATION"
+    enforcement_mode = "DRYRUN_AUDIT_LOG_ONLY"
+    require_attestations_by = [
+      module.build-attestor.attestor
+    ]
+  }
+
+}

--- a/1_clusters/binary-auth.tf
+++ b/1_clusters/binary-auth.tf
@@ -11,19 +11,16 @@ resource "null_resource" "resource-to-wait-on" {
 resource "google_kms_key_ring" "keyring" {
   name     = "attestor-key-ring-${random_pet.keyring-name.id}"
   location = var.keyring-region
-  lifecycle {
-    prevent_destroy = false
-  }
   depends_on = [null_resource.resource-to-wait-on]
 }
 
 locals {
-    attestors = [
-        # Note: module for_each support coming soon
-        "quality",
-        "build",
-        "security"
-    ]
+  attestors = [
+    # Note: module for_each support coming soon
+    "quality",
+    "build",
+    "security"
+  ]
   admin_enabled_apis = [
     "containeranalysis.googleapis.com",
     "binaryauthorization.googleapis.com",
@@ -47,7 +44,7 @@ module "project-services" {
 module "quality-attestor" {
   source = "terraform-google-modules/kubernetes-engine/google//modules/binary-authorization"
 
-project_id = var.project_id
+  project_id = var.project_id
 
   attestor-name = local.attestors[0]
   keyring-id    = google_kms_key_ring.keyring.id
@@ -57,7 +54,7 @@ project_id = var.project_id
 module "build-attestor" {
   source = "terraform-google-modules/kubernetes-engine/google//modules/binary-authorization"
 
-project_id = var.project_id
+  project_id = var.project_id
 
   attestor-name = local.attestors[1]
   keyring-id    = google_kms_key_ring.keyring.id
@@ -67,7 +64,7 @@ project_id = var.project_id
 module "security-attestor" {
   source = "terraform-google-modules/kubernetes-engine/google//modules/binary-authorization"
 
-project_id = var.project_id
+  project_id = var.project_id
 
   attestor-name = local.attestors[2]
   keyring-id    = google_kms_key_ring.keyring.id
@@ -75,7 +72,7 @@ project_id = var.project_id
 
 resource "google_binary_authorization_policy" "policy" {
   admission_whitelist_patterns {
-      # TODO: Figure out pattern for Gitlab's repo
+    # TODO: Figure out pattern for Gitlab's repo
     name_pattern = "quay.io/random-containers/*"
   }
 

--- a/1_clusters/modules/anthos-platform-cluster/main.tf
+++ b/1_clusters/modules/anthos-platform-cluster/main.tf
@@ -57,6 +57,8 @@ module "anthos_platform_cluster" {
   kubernetes_version = var.gke_kubernetes_version
   regional           = true
 
+  enable_binary_authorization = true
+
   create_service_account = false
   service_account        = google_service_account.service_account.email
   identity_namespace     = "${var.project_id}.svc.id.goog"

--- a/1_clusters/modules/anthos-platform-cluster/outputs.tf
+++ b/1_clusters/modules/anthos-platform-cluster/outputs.tf
@@ -19,3 +19,12 @@ output "service_account" {
   description = "Service account used to create the cluster and node pool(s)"
 }
 
+output "region" {
+  value       = var.region
+  description = "Region for development cluster"
+}
+
+output "cluster-name" {
+  value       = var.name
+  description = "Cluster Name"
+}

--- a/1_clusters/variables.tf
+++ b/1_clusters/variables.tf
@@ -17,3 +17,9 @@
 variable "project_id" {
   description = "The project ID to host the cluster in"
 }
+
+variable keyring-region {
+  type        = string
+  default     = "us-central1"
+  description = "Region used for key-ring"
+}

--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ Within GitLab you will have the following repo structure:
     export PROJECT_NUMBER=$(gcloud projects describe ${PROJECT_ID} --format 'value(projectNumber)')
     gcloud services enable cloudbuild.googleapis.com
     gcloud services enable serviceusage.googleapis.com
+    gcloud services enable cloudkms.googleapis.com
     gcloud projects add-iam-policy-binding ${PROJECT_ID} --member serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com   --role roles/owner
+    gcloud projects add-iam-policy-binding ${PROJECT_ID} --member serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com   --role roles/containeranalysis.admin
     ```
 
 1. Provision the address that GitLab will use.
@@ -111,7 +113,7 @@ Within GitLab you will have the following repo structure:
 1. Run Cloud Build to create the necessary resources.
 
     ```shell
-    export DOMAIN=platform.example.org
+    export DOMAIN=platform.example.org #note, do not prepend "gitlab"
     gcloud builds submit --substitutions=_DOMAIN=${DOMAIN}
     ```
 

--- a/cloudbuild-destroy.yaml
+++ b/cloudbuild-destroy.yaml
@@ -85,8 +85,28 @@ steps:
       gcloud compute networks delete anthos-platform --quiet
     fi
 
+    if [ $(gcloud container binauthz attestors list) -ne 0 ]; then
+      # Remove Attestors
+      for attestor in $(gcloud container binauthz attestors list --format="value('name')"); do
+        gcloud container binauthz attestors delete $attestor
+      done
+
+      # Remove notes (because gcloud does not remove them)
+      access=$(gcloud auth print-access-token)
+      notes=$(curl -v -X GET -H "Authorization: Bearer ${access}" "https://containeranalysis.googleapis.com/v1/projects/${PROJECT_ID}/notes/")
+
+      if [ $(echo $notes | wc -l) -gt 1 ]; then
+          for NOTE_ID in $(echo $notes | jq -r '.notes[].name' ); do
+              curl -vvv -X DELETE \
+                  -H "Authorization: Bearer ${access}" \
+                  "https://containeranalysis.googleapis.com/v1/projects/${PROJECT_ID}/notes/${NOTE_ID##*/}"
+          done
+      fi
+
+    fi
+
     for bucket in $(gsutil ls); do
       [[ $bucket = gs://${PROJECT_ID}* ]] && gsutil rm -rf ${bucket}
     done
     gsutil rm -rf gs://artifacts.${PROJECT_ID}.appspot.com/ || true
-    
+

--- a/cloudbuild-destroy.yaml
+++ b/cloudbuild-destroy.yaml
@@ -85,24 +85,24 @@ steps:
       gcloud compute networks delete anthos-platform --quiet
     fi
 
-    if [ $(gcloud container binauthz attestors list) -ne 0 ]; then
-      # Remove Attestors
-      for attestor in $(gcloud container binauthz attestors list --format="value('name')"); do
-        gcloud container binauthz attestors delete $attestor
-      done
+    attestors=$(gcloud container binauthz attestors list --format="value('name')")
 
-      # Remove notes (because gcloud does not remove them)
-      access=$(gcloud auth print-access-token)
-      notes=$(curl -v -X GET -H "Authorization: Bearer ${access}" "https://containeranalysis.googleapis.com/v1/projects/${PROJECT_ID}/notes/")
+    if [ $(echo $attestors | wc -w) -gt 0 ]; then
+        # Remove Attestors
+        for attestor in $attestors; do
+            gcloud container binauthz attestors delete $attestor
+        done
 
-      if [ $(echo $notes | wc -l) -gt 1 ]; then
-          for NOTE_ID in $(echo $notes | jq -r '.notes[].name' ); do
-              curl -vvv -X DELETE \
-                  -H "Authorization: Bearer ${access}" \
-                  "https://containeranalysis.googleapis.com/v1/projects/${PROJECT_ID}/notes/${NOTE_ID##*/}"
-          done
-      fi
-
+        # Remove notes (because gcloud does not remove them)
+        access=$(gcloud auth print-access-token)
+        notes=$(curl -H "Authorization: Bearer ${access}" "https://containeranalysis.googleapis.com/v1/projects/${PROJECT_ID}/notes/")
+        if [ "$notes" != "{}" ]; then
+            for NOTE_ID in $(echo $notes | jq -r '.notes[].name' ); do
+                curl -vvv -X DELETE \
+                    -H "Authorization: Bearer ${access}" \
+                    "https://containeranalysis.googleapis.com/v1/projects/${PROJECT_ID}/notes/${NOTE_ID##*/}"
+            done
+        fi
     fi
 
     for bucket in $(gsutil ls); do

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -24,7 +24,10 @@ gcloud config set project ${PROJECT_ID}
 # Configure Cloud BUild
 export PROJECT_NUMBER=$(gcloud projects describe ${PROJECT_ID} --format 'value(projectNumber)')
 gcloud services enable cloudbuild.googleapis.com
+gcloud services enable serviceusage.googleapis.com
+gcloud services enable cloudkms.googleapis.com
 gcloud projects add-iam-policy-binding ${PROJECT_ID} --member serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com   --role roles/owner
+gcloud projects add-iam-policy-binding ${PROJECT_ID} --member serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com   --role roles/containeranalysis.admin
 
 # Allocate GitLab Address
 gcloud services enable compute.googleapis.com


### PR DESCRIPTION
Adding binary authorization after moving the infrastructure to a module in an upstream terraform project for reuse

This addition creates a policy that is set in DRY-RUN mode allowing images to be run on the cluster even if they fail the attestation requirements.