### PR TITLE
Implement app removal via CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ target/
 
 .envrc
 projects/
+
+cli/anthos-platform-cli
+cli/release/

--- a/cli/cmd/remove.go
+++ b/cli/cmd/remove.go
@@ -21,13 +21,10 @@ import (
 // removeCmd represents the remove command
 var removeCmd = &cobra.Command{
 	Use:   "remove",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
+	Short: "Remove resources from an Anthos Platform installation",
+	Long: `Remove resources from an Anthos Platform installation:
 
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+anthos-platform-cli remove < app | cluster > `,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},

--- a/cli/cmd/removeApp.go
+++ b/cli/cmd/removeApp.go
@@ -84,14 +84,6 @@ var removeAppCmd = &cobra.Command{
 
 		gitlabHostname, gitlabToken := getGitLabParams(cmd)
 
-		templateNamespace, err := cmd.Flags().GetString("template-namespace")
-		if err != nil {
-			log.Fatal("Unable to parse template namespace name")
-		}
-		if templateNamespace == "" {
-			log.Fatal("Provide a template namespace.")
-		}
-
 		artifactRegistryLocation, err := cmd.Flags().GetString("artifact-registry-location")
 		if err != nil {
 			log.Fatal("Unable to parse Artifact Registry location")
@@ -118,7 +110,7 @@ var removeAppCmd = &cobra.Command{
 		// Remove group (contains both app and -env repos)
 		resources.DeleteGroup(client, name)
 
-		// Remove app from ACM
+		// Remove app from ACM and so from clusters
 		resources.RemoveAppFromACM(client, name, tmpKeyPath)
 
 		// Remove Artifact Registry repo and credentials

--- a/cli/cmd/removeApp.go
+++ b/cli/cmd/removeApp.go
@@ -1,0 +1,145 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"anthos-platform/anthos-platform-cli/pkg/resources"
+	"bufio"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	gitlab "github.com/xanzy/go-gitlab"
+
+	"github.com/spf13/cobra"
+)
+
+func userConfirmsRemove(appName string) bool {
+	message := `
+
+ This command will remove all data from the platform related to the following app:
+
+ %s
+
+ This includes:
+
+ - All app repositories from GitLab, including ALL application source code
+ - All app images from GCP Artifact Registry
+ - All app configuration data from the Anthos Config Management repository
+ - All running applications and any associated platform resources such as load balancers
+
+ This operation is permanent and no deleted data can be recovered.
+
+ Please respond with 'y' or 'yes' to continue, or anything else to cancel:
+
+ `
+	fmt.Printf(message, appName)
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	response = strings.ToLower(strings.TrimSpace(response))
+
+	if response == "y" || response == "yes" {
+		return true
+	} else {
+		return false
+	}
+}
+
+var removeAppCmd = &cobra.Command{
+	Use:   "app",
+	Short: "Remove an app from an Anthos Platform installation",
+	Long:  `anthos-platform-cli remove app [app-name]`,
+	Run: func(cmd *cobra.Command, args []string) {
+		name, err := cmd.Flags().GetString("name")
+		if err != nil {
+			log.Fatal("Unable to parse name for the application")
+		}
+		if name == "" {
+			log.Fatal("Provide a name for the application")
+		}
+
+		if userConfirmsRemove(name) != true {
+			log.Printf("Exiting without changes")
+			os.Exit(0)
+		}
+
+		gitlabHostname, gitlabToken := getGitLabParams(cmd)
+
+		templateNamespace, err := cmd.Flags().GetString("template-namespace")
+		if err != nil {
+			log.Fatal("Unable to parse template namespace name")
+		}
+		if templateNamespace == "" {
+			log.Fatal("Provide a template namespace.")
+		}
+
+		artifactRegistryLocation, err := cmd.Flags().GetString("artifact-registry-location")
+		if err != nil {
+			log.Fatal("Unable to parse Artifact Registry location")
+		}
+
+		// Create SSH keys that will be used to push and pull Git repos
+		tmpKeyName := "remove-app"
+		tmpKeyPath := name + "/" + tmpKeyName
+		resources.CreateSSHKey(tmpKeyName, name)
+
+		// Configure GitLab client TODO pull out into helper
+		gitlabInsecure, err := cmd.Flags().GetBool("gitlab-insecure")
+		tr := &http.Transport{}
+		if gitlabInsecure {
+			tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		}
+		httpClient := &http.Client{Transport: tr}
+		client := gitlab.NewClient(httpClient, gitlabToken)
+		client.SetBaseURL(fmt.Sprintf("https://%s/", gitlabHostname))
+
+		// Delete workload identity binding & SA
+		resources.DeleteWorkloadIdentity(name)
+
+		// Remove group (contains both app and -env repos)
+		resources.DeleteGroup(client, name)
+
+		// Remove app from ACM
+		resources.RemoveAppFromACM(client, name, tmpKeyPath)
+
+		// Remove Artifact Registry repo and credentials
+		resources.DeleteRepository(name, artifactRegistryLocation)
+
+	},
+}
+
+func init() {
+	removeCmd.AddCommand(removeAppCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	removeAppCmd.PersistentFlags().StringP("name", "n", "", "Name of the application")
+	removeAppCmd.PersistentFlags().String("template-name", "", "Template project to use as source")
+	removeAppCmd.PersistentFlags().String("template-namespace", "platform-admins", "Template namespace")
+	removeAppCmd.PersistentFlags().String("artifact-registry-location", "us-central1", "Location for Artifact Registry")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// appCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cli/pkg/resources/ar.go
+++ b/cli/pkg/resources/ar.go
@@ -96,14 +96,14 @@ func CreateRepository(repoName string, location string) (string, string) {
 		log.Fatalf("Unable to list Artifact Registry repos: %v\n%s", err, output)
 	}
 
-	fullRepoName := fmt.Sprintf("projects/%s/locations/%s/repositories/%s", 
-																projectName, location, repoName)
+	fullRepoName := fmt.Sprintf("projects/%s/locations/%s/repositories/%s",
+		projectName, location, repoName)
 	if strings.Contains(string(output), fullRepoName) {
 		log.Printf("Artifact Registry repo %v already exists", repoName)
 	} else {
 		formatArg := "--repository-format=docker"
 		log.Printf("Creating AR repository %v in location %v", repoName, location)
-	
+
 		cmd := exec.Command("gcloud",
 			"beta",
 			"artifacts",
@@ -112,7 +112,7 @@ func CreateRepository(repoName string, location string) (string, string) {
 			repoName,
 			locationArg,
 			formatArg)
-	
+
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			log.Fatalf("Unable to create Artifact Registry repository %v: %s\n", repoName, output)
@@ -134,14 +134,15 @@ func CreateRepository(repoName string, location string) (string, string) {
 func DeleteRepository(repoName string, location string) {
 
 	locationArg := "--location=" + location
+	quietArg := "--quiet"
 
 	log.Printf("Deleting AR repository %v in location %v", repoName, location)
 
 	projectName := GetCurrentProject()
-	serviceAccountName, serviceAccountEmail := constructSA(repoName, projectName)
+	_, serviceAccountEmail := constructSA(repoName, projectName)
 
 	removeSABinding(repoName, serviceAccountEmail, location)
-	DeleteSA(serviceAccountName)
+	DeleteSA(serviceAccountEmail)
 
 	cmd := exec.Command("gcloud",
 		"beta",
@@ -149,10 +150,11 @@ func DeleteRepository(repoName string, location string) {
 		"repositories",
 		"delete",
 		repoName,
-		locationArg)
+		locationArg,
+		quietArg)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Fatalf("Unable to create Artifact Registry repository %v: %s\n", repoName, output)
+		log.Fatalf("Unable to delete Artifact Registry repository %v: %s\n", repoName, output)
 	}
 }

--- a/cli/pkg/resources/gitlab.go
+++ b/cli/pkg/resources/gitlab.go
@@ -54,6 +54,20 @@ func CreateGroup(client *gitlab.Client, name string) *gitlab.Group {
 	return group
 }
 
+func DeleteGroup(client *gitlab.Client, name string) {
+	log.Printf("Deleting group: %s", name)
+	group, err := GetGroup(client, name)
+	if group == nil || err != nil {
+		log.Printf("Error retrieving group %s for deletion. Continuing...", name)
+		return
+	}
+	_, err = client.Groups.DeleteGroup(group.ID)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return
+}
+
 func GetGroup(client *gitlab.Client, gid interface{}) (*gitlab.Group, error) {
 	group, _, err := client.Groups.GetGroup(gid)
 	if err != nil {

--- a/cli/pkg/resources/iam.go
+++ b/cli/pkg/resources/iam.go
@@ -32,7 +32,7 @@ func CreateSA(name string, description string) {
 		"service-accounts",
 		"list",
 		filterArg,
-	  formatArg)
+		formatArg)
 	output, err := cmd.CombinedOutput()
 
 	if strings.Contains(string(output), name) {
@@ -74,7 +74,6 @@ func DeleteSA(serviceAccountName string) {
 	}
 }
 
-
 func CreateSAKey(serviceAccountEmail string) string {
 
 	serviceAccountArg := "--iam-account=" + serviceAccountEmail
@@ -108,7 +107,6 @@ func CreateSAKey(serviceAccountEmail string) string {
 	return string(buf)
 }
 
-
 func AddSAIAMPolicyBinding(name string, role string, serviceAccountEmail string) {
 
 	memberArg := "--member=serviceAccount:" + serviceAccountEmail
@@ -125,5 +123,24 @@ func AddSAIAMPolicyBinding(name string, role string, serviceAccountEmail string)
 
 	if err != nil {
 		log.Fatalf("Unable to add binding for service account %v: %s\n", serviceAccountEmail, output)
+	}
+}
+
+func RemoveSAIAMPolicyBinding(name string, role string, serviceAccountEmail string) {
+
+	memberArg := "--member=serviceAccount:" + serviceAccountEmail
+	roleArg := "--role=" + role
+
+	cmd := exec.Command("gcloud",
+		"iam",
+		"service-accounts",
+		"remove-iam-policy-binding",
+		name,
+		memberArg,
+		roleArg)
+	output, err := cmd.CombinedOutput()
+
+	if err != nil {
+		log.Fatalf("Unable to remove binding for service account %v: %s\n", serviceAccountEmail, output)
 	}
 }

--- a/cli/pkg/resources/wi.go
+++ b/cli/pkg/resources/wi.go
@@ -1,0 +1,61 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func getGSAName(appName string) string {
+	return appName + "-gsa"
+}
+
+func getBindingName(projectID string, gsaName string) string {
+	return fmt.Sprintf("%s@%s.iam.gserviceaccount.com", gsaName, projectID)
+}
+
+func getWiName(projectID string, appName string) string {
+	return fmt.Sprintf("%s.svc.id.goog[%s/%s-ksa]", projectID, appName, appName)
+}
+
+// CreateWorkloadIdentity creates SA and binding for WI
+// See https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#creating_a_relationship_between_ksas_and_gsas
+func CreateWorkloadIdentity(appName string) {
+
+	log.Printf("Creating workload identity for %s", appName)
+
+	projectID := GetCurrentProject()
+	gsaName := getGSAName(appName)
+	CreateSA(gsaName, "Map KSA to GSA for "+appName)
+
+	bindingName := getBindingName(projectID, gsaName)
+	wiName := getWiName(projectID, appName)
+	AddSAIAMPolicyBinding(bindingName, "roles/iam.workloadIdentityUser", wiName)
+}
+
+// DeleteWorkloadIdentity deletes SA and binding for WI
+func DeleteWorkloadIdentity(appName string) {
+
+	log.Printf("Removing workload identity for %s", appName)
+
+	projectID := GetCurrentProject()
+	gsaName := getGSAName(appName)
+	bindingName := getBindingName(projectID, gsaName)
+	wiName := getWiName(projectID, appName)
+	RemoveSAIAMPolicyBinding(bindingName, "roles/iam.workloadIdentityUser", wiName)
+	DeleteSA(bindingName)
+}


### PR DESCRIPTION
This adds `anthos-platform-cli remove app` to the CLI. When invoked with the name of an application, this results in the deletion of the following for the supplied app:

- All app repositories from GitLab, including ALL application source code
 - All app images from GCP Artifact Registry, and the repository itself
 - All app configuration data from the Anthos Config Management repository
 - All running applications and any associated platform resources such as load balancers

When run, this subcommand displays a warning (that includes the above list) and prompts the user before continuing with the deletion.

