### PR TITLE
this readme can be confusing, because this folder is acm specific

### DIFF
--- a/starter-repos/anthos-config-management/cluster/README.md
+++ b/starter-repos/anthos-config-management/cluster/README.md
@@ -1,25 +1,6 @@
-# Constraints with Policy Controller
+# ACM cluster directory
 
-You can place constraint templates and constraints that you want to be
-applied everywhere in this directory.
-
-For example, if you want to enforce the presence of a "team" label on
-Namespace objects, place the following content in a file:
-
-```
-apiVersion: constraints.gatekeeper.sh/v1beta1
-kind: K8sRequiredLabels
-metadata:
-  name: ns-must-have-geo
-spec:
-  match:
-    kinds:
-      - apiGroups: [""]
-        kinds: ["Namespace"]
-  parameters:
-    labels:
-      - key: "team"
-```
-
-See the [Policy Controller](https://cloud.google.com/anthos-config-management/docs/how-to/creating-constraints-and-templates)
-documentation for more information.
+This directory contains configs that apply to entire clusters, rather
+than to namespaces. By default, any config in this directory applies to
+every cluster enrolled in Anthos Config Management. You can limit which clusters
+a config can affect by using a ClusterSelector.


### PR DESCRIPTION
though it's embedded as users start making changes to the starter repos, this readme can be misleading as it's not specific to policy controller.