### PR TITLE
Adding a version command to the CLI 

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -10,10 +10,15 @@ VERSION ?= vlatest
 PLATFORMS := windows linux darwin
 os = $(word 1, $@)
 
+VERSION_MAJOR=0
+VERSION_MINOR=0
+VERSION_PATCH=1
+$(eval GIT_COMMIT=$(shell sh -c "git rev-parse --short HEAD"))
+
 .PHONY: $(PLATFORMS)
 $(PLATFORMS):
 		mkdir -p release
-		GOOS=$(os) GOARCH=amd64 go build -o release/$(BINARY)-$(VERSION)-$(os)-amd64
+		GOOS=$(os) GOARCH=amd64 go build -o release/$(BINARY)-$(VERSION)-$(os)-amd64 -ldflags "-X main.VersionNumber=${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}-$(GIT_COMMIT)"
 
 .PHONY: release
 release: windows linux darwin

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -10,15 +10,12 @@ VERSION ?= vlatest
 PLATFORMS := windows linux darwin
 os = $(word 1, $@)
 
-VERSION_MAJOR=0
-VERSION_MINOR=0
-VERSION_PATCH=1
 $(eval GIT_COMMIT=$(shell sh -c "git rev-parse --short HEAD"))
 
 .PHONY: $(PLATFORMS)
 $(PLATFORMS):
 		mkdir -p release
-		GOOS=$(os) GOARCH=amd64 go build -o release/$(BINARY)-$(VERSION)-$(os)-amd64 -ldflags "-X main.VersionNumber=${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}-$(GIT_COMMIT)"
+		GOOS=$(os) GOARCH=amd64 go build -o release/$(BINARY)-$(VERSION)-$(os)-amd64 -ldflags "-X main.VersionNumber=$(GIT_COMMIT) -X main.Binary=${BINARY}"
 
 .PHONY: release
 release: windows linux darwin

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -15,7 +15,7 @@
 package cmd
 
 import (
-	version "anthos-platform/anthos-platform-cli/pkg/resources"
+	"anthos-platform/anthos-platform-cli/pkg/resources"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -31,8 +31,11 @@ var versionCmd = &cobra.Command{
 	Long:  `This is the X Version of the application`,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		version := version.GetBuildVersion()
+		version := resources.GetBuildVersion()
+		binary := resources.BinaryName()
 
-		fmt.Printf("App Version: %s\n", version)
+		// binary := "Anthos Platform"
+
+		fmt.Printf("%s: %s\n", binary, version)
 	},
 }

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -12,17 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
-	"anthos-platform/anthos-platform-cli/cmd"
 	version "anthos-platform/anthos-platform-cli/pkg/resources"
+	"fmt"
+
+	"github.com/spf13/cobra"
 )
 
-var VersionNumber string
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}
 
-func main() {
-	version.SetBuildNumber(VersionNumber)
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Prints the version of this application",
+	Long:  `This is the X Version of the application`,
+	Run: func(cmd *cobra.Command, args []string) {
 
-	cmd.Execute()
+		version := version.GetBuildVersion()
+
+		fmt.Printf("App Version: %s\n", version)
+	},
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -20,9 +20,11 @@ import (
 )
 
 var VersionNumber string
+var Binary string
 
 func main() {
 	version.SetBuildNumber(VersionNumber)
+	version.SetBinary(Binary)
 
 	cmd.Execute()
 }

--- a/cli/pkg/resources/version.go
+++ b/cli/pkg/resources/version.go
@@ -1,0 +1,19 @@
+package resources
+
+// VersionNumber holds the build-number passed at build-time
+var VersionNumber string
+
+//GetBuildVersion provides the build version for output
+func GetBuildVersion() string {
+	ver := "UNKNOWN"
+	if VersionNumber != "" {
+		ver = VersionNumber
+
+	}
+	return ver
+}
+
+// SetBuildNumber provids a method to set the build number for testing purposes
+func SetBuildNumber(number string) {
+	VersionNumber = number
+}

--- a/cli/pkg/resources/version.go
+++ b/cli/pkg/resources/version.go
@@ -5,12 +5,14 @@ package resources
 // VersionNumber holds the build-number passed at build-time
 var VersionNumber string
 
-//GetBuildVersion provides the build version for output
+// Binary holds the name of the binary set in Makefile
+var Binary string
+
+// GetBuildVersion provides the build version for output with a default fallback
 func GetBuildVersion() string {
 	ver := "UNKNOWN"
 	if VersionNumber != "" {
 		ver = VersionNumber
-
 	}
 	return ver
 }
@@ -18,4 +20,18 @@ func GetBuildVersion() string {
 // SetBuildNumber provids a method to set the build number for testing purposes
 func SetBuildNumber(number string) {
 	VersionNumber = number
+}
+
+// BinaryName provides binary name for output with a default fallback
+func BinaryName() string {
+	ret := ""
+	if Binary != "" {
+		ret = Binary
+	}
+	return ret
+}
+
+// SetBinary is the setter for the name of the binary artifact
+func SetBinary(binaryName string) {
+	Binary = binaryName
 }

--- a/cli/pkg/resources/version.go
+++ b/cli/pkg/resources/version.go
@@ -1,3 +1,5 @@
+// Copyright 2020 Google LLC
+
 package resources
 
 // VersionNumber holds the build-number passed at build-time


### PR DESCRIPTION
Using the Git short-sha hash as a semver-label.  The "version" is currently hard-coded but the SHA hash is pulled in at build-time and passed to the main function, which sends to a delegate Version object for use by the Version command