### PR TITLE
Add hint so that Skaffold recognizes go runtime

### DIFF
--- a/starter-repos/golang-template/k8s/dev/deployment.yaml
+++ b/starter-repos/golang-template/k8s/dev/deployment.yaml
@@ -23,5 +23,9 @@ spec:
       containers:
       - name: app
         env:
+        # Required for Skaffold to detect runtime language
+        # https://skaffold.dev/docs/workflows/debug/#go
+        - name: GOTRACEBACK
+          value: single
         - name: ENVIRONMENT
           value: dev


### PR DESCRIPTION
Skaffold requires a GO* environment variable to be set in order to detect that an app can be debugged using the golang runtime.