### PR TITLE
Use skaffold to build and hydrate manifests

### DIFF
--- a/starter-repos/golang-template/.gitlab-ci.yml
+++ b/starter-repos/golang-template/.gitlab-ci.yml
@@ -16,9 +16,9 @@ include:
 - project: 'platform-admins/shared-ci-cd'
   file: 'ci/go-docker.yaml'
 - project: 'platform-admins/shared-ci-cd'
-  file: 'ci/kaniko.yaml'
+  file: 'skaffold/build.yaml'
 - project: 'platform-admins/shared-ci-cd'
-  file: 'cd/kustomize.yaml'
+  file: 'skaffold/render.yaml'
 - project: 'platform-admins/shared-ci-cd'
   file: 'cd/validate.yaml'
 - project: 'platform-admins/shared-ci-cd'
@@ -27,7 +27,7 @@ include:
 stages:
   - test
   - build
-  - hydrate-manifests
+  - render-manifests
   - prepare-config
   - validate-config
   - push-manifests

--- a/starter-repos/golang-template/skaffold.yaml
+++ b/starter-repos/golang-template/skaffold.yaml
@@ -12,11 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v1beta14
+apiVersion: skaffold/v2beta5
 kind: Config
+# Defaults are configured for local dev
 build:
   artifacts:
   - image: app
 deploy:
   kustomize:
-    path: k8s/dev
+    paths:
+    - k8s/dev
+profiles:
+  # Profile used when building images in CI
+  - name: ci
+    build:
+      cluster:
+        dockerConfig:
+          path: ~/.docker/config.json
+  # Profile used when rendering production manifests
+  - name: prod
+    deploy:
+      kustomize:
+        paths:
+        - k8s/prod
+  # Profile used when rendering staging manifests
+  - name: staging
+    deploy:
+      kustomize:
+        paths:
+        - k8s/stg

--- a/starter-repos/java-template/.gitlab-ci.yml
+++ b/starter-repos/java-template/.gitlab-ci.yml
@@ -16,9 +16,9 @@ include:
 - project: 'platform-admins/shared-ci-cd'
   file: 'ci/java-docker.yaml'
 - project: 'platform-admins/shared-ci-cd'
-  file: 'ci/kaniko.yaml'
+  file: 'skaffold/build.yaml'
 - project: 'platform-admins/shared-ci-cd'
-  file: 'cd/kustomize.yaml'
+  file: 'skaffold/render.yaml'
 - project: 'platform-admins/shared-ci-cd'
   file: 'cd/validate.yaml'
 - project: 'platform-admins/shared-ci-cd'
@@ -27,7 +27,7 @@ include:
 stages:
   - test
   - build
-  - hydrate-manifests
+  - render-manifests
   - prepare-config
   - validate-config
   - push-manifests

--- a/starter-repos/java-template/skaffold.yaml
+++ b/starter-repos/java-template/skaffold.yaml
@@ -12,11 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v1beta14
+apiVersion: skaffold/v2beta5
 kind: Config
+# Defaults are configured for local dev
 build:
   artifacts:
   - image: app
 deploy:
   kustomize:
-    path: k8s/dev
+    paths:
+    - k8s/dev
+profiles:
+  # Profile used when building images in CI
+  - name: ci
+    build:
+      cluster:
+        dockerConfig:
+          path: ~/.docker/config.json
+  # Profile used when rendering production manifests
+  - name: prod
+    deploy:
+      kustomize:
+        paths:
+        - k8s/prod
+  # Profile used when rendering staging manifests
+  - name: staging
+    deploy:
+      kustomize:
+        paths:
+        - k8s/stg

--- a/starter-repos/shared-ci-cd/skaffold/build.yaml
+++ b/starter-repos/shared-ci-cd/skaffold/build.yaml
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+skaffold-build:
+  stage: build
+  image: gcr.io/k8s-skaffold/skaffold:v1.12.0
+  script:
+    # Setup image registry credentials
+    - "[ -z ${GCP_AR_KEY} ] && echo 'Artifact Registry credentials not available' && exit 1"
+    - "[ -z ${GCP_AR_REPO} ] && echo 'Artifact Registry location not available' && exit 1"
+    - printf '%s\n' "${GCP_AR_KEY}" | docker login -u _json_key --password-stdin "${GCP_AR_REPO}"
+    # Setup environment
+    - export SKAFFOLD_DEFAULT_REPO=${GCP_AR_REPO}
+    - export SKAFFOLD_LOUD=true
+    - export SKAFFOLD_TAG=${CI_COMMIT_SHA}
+    # Build the images
+    - skaffold build -p ci

--- a/starter-repos/shared-ci-cd/skaffold/render.yaml
+++ b/starter-repos/shared-ci-cd/skaffold/render.yaml
@@ -1,0 +1,36 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+skaffold-render:
+  stage: render-manifests
+  image: gcr.io/k8s-skaffold/skaffold:v1.12.0
+  script:
+    # Setup image registry credentials
+    - "[ -z ${GCP_AR_KEY} ] && echo 'Artifact Registry credentials not available' && exit 1"
+    - "[ -z ${GCP_AR_REPO} ] && echo 'Artifact Registry location not available' && exit 1"
+    - printf '%s\n' "${GCP_AR_KEY}" | docker login -u _json_key --password-stdin "${GCP_AR_REPO}"
+    # Configure git auth
+    - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@${CI_SERVER_HOST}".insteadOf "https://${CI_SERVER_HOST}"
+    # Setup environment
+    - export SKAFFOLD_DEFAULT_REPO=${GCP_AR_REPO}
+    - export SKAFFOLD_LOUD=true
+    - export SKAFFOLD_TAG=${CI_COMMIT_SHA}
+    # Build images and render manifests
+    - skaffold render --digest-source=remote -p staging --output /tmp/stg.yaml
+    - skaffold render --digest-source=remote -p prod --output /tmp/prod.yaml
+    - mkdir -p hydrated-manifests/
+    - cp /tmp/stg.yaml /tmp/prod.yaml hydrated-manifests/
+  artifacts:
+    paths:
+      - hydrated-manifests/


### PR DESCRIPTION
This will leverage `skaffold render` to do the image build and manifest hydration for the main CI/CD pipelines. ATM I'm only switching over the java-template and golang-template. The other CI/CD snippets are going to left in place as they are used by other apps and I don't want to break those flows since they dont leverage Skaffold in all cases.