### PR TITLE
Pin Terraform providers to a specific version

### DIFF
--- a/1_clusters/clusters.tf
+++ b/1_clusters/clusters.tf
@@ -20,12 +20,12 @@ locals {
 
 provider "google" {
   project = var.project_id
-  version = "~> 3.13"
+  version = "= 3.28.0"
 }
 
 provider "google-beta" {
   project = var.project_id
-  version = "~> 3.13"
+  version = "= 3.28.0"
 }
 
 data "google_compute_network" "anthos-platform" {


### PR DESCRIPTION
This is to unblock an apparent issue with 3.29.0:

https://github.com/terraform-providers/terraform-provider-google/issues/6744

3.28.0 validated working to build clusters.

