### PR TITLE
Pin TF provider

### DIFF
--- a/2_gitlab/versions.tf
+++ b/2_gitlab/versions.tf
@@ -17,3 +17,11 @@
 terraform {
   required_version = ">= 0.12"
 }
+
+provider "google" {
+  version = "= 3.28.0"
+}
+
+provider "google-beta" {
+  version = "= 3.28.0"
+}


### PR DESCRIPTION
This pins the Google Terraform providers in use for GitLab to work around an issue in 3.29.0:

https://github.com/terraform-providers/terraform-provider-google/issues/6744