### PR TITLE
Use Cloud Endpoints for DNS

### DIFF
--- a/0_foundation/backend.tf
+++ b/0_foundation/backend.tf
@@ -16,7 +16,7 @@
 
 terraform {
   backend "gcs" {
-    bucket  = "YOUR_PROJECT_ID-anthos-platform-tf-state"
-    prefix  = "foundation"
+    bucket = "YOUR_PROJECT_ID-anthos-platform-tf-state"
+    prefix = "foundation"
   }
 }

--- a/0_foundation/services.tf
+++ b/0_foundation/services.tf
@@ -22,7 +22,7 @@ module "project-services" {
 
   # Don't disable the services
   disable_services_on_destroy = false
-  disable_dependent_services = false
+  disable_dependent_services  = false
 
   activate_apis = [
     "compute.googleapis.com",

--- a/1_clusters/backend.tf
+++ b/1_clusters/backend.tf
@@ -16,7 +16,7 @@
 
 terraform {
   backend "gcs" {
-    bucket  = "YOUR_PROJECT_ID-anthos-platform-tf-state"
-    prefix  = "clusters"
+    bucket = "YOUR_PROJECT_ID-anthos-platform-tf-state"
+    prefix = "clusters"
   }
 }

--- a/1_clusters/binary-auth.tf
+++ b/1_clusters/binary-auth.tf
@@ -38,9 +38,9 @@ locals {
     "security"
   ]
   admin_enabled_apis = [
-    "containeranalysis.googleapis.com",
     "binaryauthorization.googleapis.com",
     "cloudkms.googleapis.com",
+    "containeranalysis.googleapis.com",
     "secretmanager.googleapis.com"
   ]
 
@@ -66,6 +66,9 @@ module "quality-attestor" {
 
   attestor-name = local.attestors[0]
   keyring-id    = google_kms_key_ring.keyring.id
+
+  disable_dependent_services  = false
+  disable_services_on_destroy = false
 }
 
 # Create Builder attestor
@@ -76,6 +79,9 @@ module "build-attestor" {
 
   attestor-name = local.attestors[1]
   keyring-id    = google_kms_key_ring.keyring.id
+
+  disable_dependent_services  = false
+  disable_services_on_destroy = false
 }
 
 # Create Security attestor
@@ -86,6 +92,9 @@ module "security-attestor" {
 
   attestor-name = local.attestors[2]
   keyring-id    = google_kms_key_ring.keyring.id
+
+  disable_dependent_services  = false
+  disable_services_on_destroy = false
 }
 
 resource "google_binary_authorization_policy" "policy" {

--- a/1_clusters/binary-auth.tf
+++ b/1_clusters/binary-auth.tf
@@ -25,8 +25,8 @@ resource "null_resource" "resource-to-wait-on" {
 }
 
 resource "google_kms_key_ring" "keyring" {
-  name     = "attestor-key-ring-${random_pet.keyring-name.id}"
-  location = var.keyring-region
+  name       = "attestor-key-ring-${random_pet.keyring-name.id}"
+  location   = var.keyring-region
   depends_on = [null_resource.resource-to-wait-on]
 }
 

--- a/1_clusters/clusters.tf
+++ b/1_clusters/clusters.tf
@@ -20,12 +20,12 @@ locals {
 
 provider "google" {
   project = var.project_id
-  version = "= 3.28.0"
+  version = "~> 3.29.0"
 }
 
 provider "google-beta" {
   project = var.project_id
-  version = "= 3.28.0"
+  version = "~> 3.29.0"
 }
 
 data "google_compute_network" "anthos-platform" {

--- a/1_clusters/modules/anthos-platform-cluster/main.tf
+++ b/1_clusters/modules/anthos-platform-cluster/main.tf
@@ -46,7 +46,7 @@ resource "google_project_iam_member" "cluster_iam_artifactregistryreader" {
 
 module "anthos_platform_cluster" {
   source             = "terraform-google-modules/kubernetes-engine/google//modules/beta-public-cluster"
-  version            = "~> 7.3.0"
+  version            = "~> 10.0.0"
   project_id         = var.project_id
   name               = var.name
   region             = var.region

--- a/2_gitlab/backend.tf
+++ b/2_gitlab/backend.tf
@@ -16,7 +16,7 @@
 
 terraform {
   backend "gcs" {
-    bucket  = "YOUR_PROJECT_ID-anthos-platform-tf-state"
-    prefix  = "gitlab"
+    bucket = "YOUR_PROJECT_ID-anthos-platform-tf-state"
+    prefix = "gitlab"
   }
 }

--- a/2_gitlab/cloudbuild-destroy.yaml
+++ b/2_gitlab/cloudbuild-destroy.yaml
@@ -17,7 +17,6 @@ tags:
   - modern-cicd-anthos
   - gitlab
 substitutions:
-  _DOMAIN: ""
   _BUILD_IMAGES: "true"
   _CREATE_GITLAB: "true"
   _DESTROY_CLUSTER: "true"
@@ -37,16 +36,14 @@ steps:
     sed -i "s/YOUR_PROJECT_ID/${PROJECT_ID}/g" terraform.tfvars
     sed -i "s/YOUR_PROJECT_ID/${PROJECT_ID}/g" backend.tf
     sed -i "s/YOUR_PROJECT_ID/${PROJECT_ID}/g" gitlab-repos/backend.tf
-    sed -i "s/YOUR_DOMAIN/${_DOMAIN}/g" terraform.tfvars
 
     pushd gitlab-repos
 
     terraform init
     export GITLAB_PASSWORD=$(gcloud secrets versions access latest --secret="gitlab-password")
-    export GITLAB_HOSTNAME="gitlab.${_DOMAIN}"
 
     [[ -z "$${GITLAB_PASSWORD}" ]] && exit 0 # No need to continue if no password
-    terraform destroy -auto-approve -var gitlab_token=$${GITLAB_PASSWORD} -var gitlab_hostname=$${GITLAB_HOSTNAME}
+    terraform destroy -auto-approve -var gitlab_token=$${GITLAB_PASSWORD}
 
     # remove private keys stored in secrets manager
     gcloud secrets delete "gitlab-cluster-key-$${CLUSTER}" --quiet || true
@@ -65,7 +62,11 @@ steps:
     sed -i "s/YOUR_PROJECT_ID/${PROJECT_ID}/g" terraform.tfvars
     sed -i "s/YOUR_PROJECT_ID/${PROJECT_ID}/g" backend.tf
     sed -i "s/YOUR_PROJECT_ID/${PROJECT_ID}/g" gitlab-repos/backend.tf
-    sed -i "s/YOUR_DOMAIN/${_DOMAIN}/g" terraform.tfvars
+
+    # TODO Manually empty bucket contents as otherwise gke-gitlab cannot delete them pending:
+    # https://github.com/terraform-google-modules/terraform-google-gke-gitlab/issues/49
+    gsutil rm "gs://${PROJECT_ID}-gitlab-artifacts/**" || true
+    gsutil rm "gs://${PROJECT_ID}-registry/**" || true
 
     terraform init
     terraform destroy -auto-approve

--- a/2_gitlab/cloudbuild.yaml
+++ b/2_gitlab/cloudbuild.yaml
@@ -17,7 +17,6 @@ tags:
   - modern-cicd-anthos
   - gitlab
 substitutions:
-  _DOMAIN: ""
   _BUILD_IMAGES: "true"
   _CREATE_GITLAB: "true"
 options:
@@ -34,18 +33,16 @@ steps:
     sed -i "s/YOUR_PROJECT_ID/${PROJECT_ID}/g" terraform.tfvars
     sed -i "s/YOUR_PROJECT_ID/${PROJECT_ID}/g" backend.tf
     sed -i "s/YOUR_PROJECT_ID/${PROJECT_ID}/g" gitlab-repos/backend.tf
-    sed -i "s/YOUR_DOMAIN/${_DOMAIN}/g" terraform.tfvars
 
     terraform init
     terraform plan -out=terraform.tfplan
     terraform apply -auto-approve terraform.tfplan
 
-    export GITLAB_ADDRESS=$(terraform output gitlab_address)
+    export GITLAB_HOSTNAME=$(terraform output gitlab_hostname)
 
     # Wait for GitLab domain to resolve
-    until nslookup gitlab.${_DOMAIN}; do
-      echo -e "\e[33mWaiting for gitlab.${_DOMAIN} to resolve."
-      echo -e "\e[31mAdd an A Record that points *.${_DOMAIN} to $${GITLAB_ADDRESS}"
+    until nslookup $${GITLAB_HOSTNAME}; do
+      echo -e "\e[33mWaiting for $${GITLAB_HOSTNAME} to resolve."
       sleep 10
     done
 
@@ -60,11 +57,10 @@ steps:
     sed -i "s/YOUR_PROJECT_ID/${PROJECT_ID}/g" terraform.tfvars
     sed -i "s/YOUR_PROJECT_ID/${PROJECT_ID}/g" backend.tf
     sed -i "s/YOUR_PROJECT_ID/${PROJECT_ID}/g" gitlab-repos/backend.tf
-    sed -i "s/YOUR_DOMAIN/${_DOMAIN}/g" terraform.tfvars
 
     # Copy starter repos to local workspace
     # TODO: Convert to gzip
-    gsutil cp -r gs://${PROJECT_ID}-starter-repos/starter-repos .
+    gsutil -m cp -r gs://${PROJECT_ID}-starter-repos/starter-repos .
 
     export WORKSPACEROOT=$(pwd)
     # Configure GitLab
@@ -72,9 +68,9 @@ steps:
     export GITLAB_PASSWORD=$(kubectl get secrets gitlab-gitlab-initial-root-password -o jsonpath="{.data.password}" | base64 -d)
 
     # Create a personal access token with the value of the root password
-    export UNICORN_POD=$(kubectl get pods -l=app=unicorn -o jsonpath='{.items[0].metadata.name}')
+    export WEBSERVICE_POD=$(kubectl get pods -l=app=webservice -o jsonpath='{.items[0].metadata.name}')
     export GITLAB_TOKEN=$${GITLAB_PASSWORD}
-    kubectl exec -it $$UNICORN_POD -c unicorn -- /bin/bash -c "
+    kubectl exec -it $$WEBSERVICE_POD -c webservice -- /bin/bash -c "
     cd /srv/gitlab;
     bin/rails r \"
     token_digest = Gitlab::CryptoHelper.sha256 \\\"$${GITLAB_PASSWORD}\\\";
@@ -87,7 +83,6 @@ steps:
     mkdir -p ~/.ssh
     ssh-keyscan -t rsa gitlab.${_DOMAIN} >> ~/.ssh/known_hosts
 
-    export GITLAB_HOSTNAME=gitlab.${_DOMAIN}
     git config --global user.email "anthos-platform-installer@example.com"
     git config --global user.name "Anthos Platform Installer"
 

--- a/2_gitlab/create-repos.sh
+++ b/2_gitlab/create-repos.sh
@@ -35,8 +35,10 @@ pushd gitlab-repos
   popd
 
   terraform init
-  terraform plan -var gitlab_token=${GITLAB_TOKEN} -var gitlab_hostname=${GITLAB_HOSTNAME} -var ssh-key-path-base=${WORKINGDIR}/ssh-keys -out=terraform.tfplan
+  terraform plan -var gitlab_token=${GITLAB_TOKEN} -var ssh-key-path-base=${WORKINGDIR}/ssh-keys -out=terraform.tfplan
   terraform apply -auto-approve terraform.tfplan
+
+  export GITLAB_HOSTNAME=$(terraform output gitlab_hostname)
 
   # TODO: Move into terraform sometime in the future, for now, forcefully delete in destroy
   gcloud secrets delete gitlab-user --quiet || true

--- a/2_gitlab/gitlab-repos/backend.tf
+++ b/2_gitlab/gitlab-repos/backend.tf
@@ -16,15 +16,15 @@
 
 terraform {
   backend "gcs" {
-    bucket  = "YOUR_PROJECT_ID-anthos-platform-tf-state"
-    prefix  = "gitlab-repos"
+    bucket = "YOUR_PROJECT_ID-anthos-platform-tf-state"
+    prefix = "gitlab-repos"
   }
 }
 
 data "terraform_remote_state" "gitlab" {
   backend = "gcs"
   config = {
-    bucket  = "YOUR_PROJECT_ID-anthos-platform-tf-state"
-    prefix  = "gitlab"
+    bucket = "YOUR_PROJECT_ID-anthos-platform-tf-state"
+    prefix = "gitlab"
   }
 }

--- a/2_gitlab/gitlab-repos/backend.tf
+++ b/2_gitlab/gitlab-repos/backend.tf
@@ -20,3 +20,11 @@ terraform {
     prefix  = "gitlab-repos"
   }
 }
+
+data "terraform_remote_state" "gitlab" {
+  backend = "gcs"
+  config = {
+    bucket  = "YOUR_PROJECT_ID-anthos-platform-tf-state"
+    prefix  = "gitlab"
+  }
+}

--- a/2_gitlab/gitlab-repos/outputs.tf
+++ b/2_gitlab/gitlab-repos/outputs.tf
@@ -19,7 +19,7 @@ output gitlab-token {
   description = "Token/Password"
 }
 
-output gitlab-hostname {
-  value       = var.gitlab_hostname
+output gitlab_hostname {
+  value       = data.terraform_remote_state.gitlab.outputs.gitlab_hostname
   description = "Gitlab Hostname"
 }

--- a/2_gitlab/gitlab-repos/repos.tf
+++ b/2_gitlab/gitlab-repos/repos.tf
@@ -16,7 +16,7 @@
 
 provider "gitlab" {
   token    = var.gitlab_token
-  base_url = "https://${var.gitlab_hostname}/api/v4/"
+  base_url = "https://${data.terraform_remote_state.gitlab.outputs.gitlab_hostname}/api/v4/"
   insecure = true
 }
 

--- a/2_gitlab/gitlab-repos/variables.tf
+++ b/2_gitlab/gitlab-repos/variables.tf
@@ -18,10 +18,6 @@ variable "gitlab_token" {
   description = "The token used to access the GitLab API"
 }
 
-variable "gitlab_hostname" {
-  description = "Hostname of the GitLab instance (for example my.gitlab.server)"
-}
-
 variable ssh-key-path-base {
   type        = string
   default     = "../../ssh-keys"

--- a/2_gitlab/gitlab.tf
+++ b/2_gitlab/gitlab.tf
@@ -16,17 +16,37 @@
 
 module "gke-gitlab" {
   source  = "terraform-google-modules/gke-gitlab/google"
-  version = "~> 0.1.1"
+  version = "~> 0.2.0"
 
   project_id            = var.project_id
-  domain                = var.domain
+  domain                = "${trimprefix(module.cloud-endpoints-dns-gitlab.endpoint_computed, "gitlab.")}"
   certmanager_email     = "no-reply@${var.project_id}.example.com"
-  gitlab_address_name   = "gitlab"
   gitlab_runner_install = true
+  gitlab_address_name   = google_compute_address.gitlab.name
   gitlab_db_name        = "gitlab-${lower(random_id.database_id.hex)}"
+  helm_chart_version    = "4.0.7"
+  gke_version           = "1.15"
 }
 
-data "google_compute_address" "gitlab" {
+module "cloud-endpoints-dns-gitlab" {
+  source  = "terraform-google-modules/endpoints-dns/google"
+  version = "~> 2.0.1"
+
+  project     = var.project_id
+  name        = "gitlab"
+  external_ip = google_compute_address.gitlab.address
+}
+
+module "cloud-endpoints-dns-registry" {
+  source  = "terraform-google-modules/endpoints-dns/google"
+  version = "~> 2.0.1"
+
+  project     = var.project_id
+  name        = "registry"
+  external_ip = google_compute_address.gitlab.address
+}
+
+resource "google_compute_address" "gitlab" {
   project = var.project_id
   region  = "us-central1"
   name    = "gitlab"

--- a/2_gitlab/outputs.tf
+++ b/2_gitlab/outputs.tf
@@ -15,6 +15,6 @@
  */
 
 output "gitlab_hostname" {
-  value       =  module.cloud-endpoints-dns-gitlab.endpoint_computed
+  value       = module.cloud-endpoints-dns-gitlab.endpoint_computed
   description = "GitLab endpoint hostname."
 }

--- a/2_gitlab/outputs.tf
+++ b/2_gitlab/outputs.tf
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-output "gitlab_address" {
-  value       = data.google_compute_address.gitlab.address
-  description = "Point your wildcard domain to this IP address as an A record"
-}
-
-output "gitlab_domain" {
-  value       = var.domain
-  description = "Domain used to deploy Gitlab."
+output "gitlab_hostname" {
+  value       =  module.cloud-endpoints-dns-gitlab.endpoint_computed
+  description = "GitLab endpoint hostname."
 }

--- a/2_gitlab/terraform.tfvars
+++ b/2_gitlab/terraform.tfvars
@@ -1,2 +1,1 @@
 project_id   = "YOUR_PROJECT_ID"
-domain       = "YOUR_DOMAIN"

--- a/2_gitlab/terraform.tfvars
+++ b/2_gitlab/terraform.tfvars
@@ -1,1 +1,1 @@
-project_id   = "YOUR_PROJECT_ID"
+project_id = "YOUR_PROJECT_ID"

--- a/2_gitlab/versions.tf
+++ b/2_gitlab/versions.tf
@@ -19,9 +19,9 @@ terraform {
 }
 
 provider "google" {
-  version = "= 3.28.0"
+  version = "~> 3.28.0"
 }
 
 provider "google-beta" {
-  version = "= 3.28.0"
+  version = "~> 3.28.0"
 }

--- a/3_acm/backend.tf
+++ b/3_acm/backend.tf
@@ -16,15 +16,15 @@
 
 terraform {
   backend "gcs" {
-    bucket  = "YOUR_PROJECT_ID-anthos-platform-tf-state"
-    prefix  = "acm"
+    bucket = "YOUR_PROJECT_ID-anthos-platform-tf-state"
+    prefix = "acm"
   }
 }
 
 data "terraform_remote_state" "gitlab" {
   backend = "gcs"
   config = {
-    bucket  = "YOUR_PROJECT_ID-anthos-platform-tf-state"
-    prefix  = "gitlab"
+    bucket = "YOUR_PROJECT_ID-anthos-platform-tf-state"
+    prefix = "gitlab"
   }
 }

--- a/3_acm/backend.tf
+++ b/3_acm/backend.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,17 @@
  * limitations under the License.
  */
 
-variable "project_id" {
-  description = "The project ID to host the cluster in"
+terraform {
+  backend "gcs" {
+    bucket  = "YOUR_PROJECT_ID-anthos-platform-tf-state"
+    prefix  = "acm"
+  }
+}
+
+data "terraform_remote_state" "gitlab" {
+  backend = "gcs"
+  config = {
+    bucket  = "YOUR_PROJECT_ID-anthos-platform-tf-state"
+    prefix  = "gitlab"
+  }
 }

--- a/3_acm/cloudbuild.yaml
+++ b/3_acm/cloudbuild.yaml
@@ -17,7 +17,6 @@ tags:
   - modern-cicd-anthos
   - modern-cicd-anthos-acm
 substitutions:
-  _DOMAIN: ""
   _BUILD_IMAGES: "true"
 options:
   substitution_option: 'ALLOW_LOOSE'
@@ -28,22 +27,26 @@ steps:
   args:
     - -c
     - |
+      sed -i "s/YOUR_PROJECT_ID/${PROJECT_ID}/g" backend.tf
+
       # Grab latest ACM Operator
       gsutil cp gs://config-management-release/released/latest/config-management-operator.yaml config-management-operator.yaml
 
+      terraform init
+      terraform apply
+      export GITLAB_HOSTNAME=$(terraform output gitlab_hostname)
       export GITLAB_PASSWORD=$(gcloud secrets versions access latest --secret="gitlab-password")
-      export GITLAB_HOSTNAME="gitlab.${_DOMAIN}"
 
       cat > auth.txt <<EOF
       grant_type=password&username=root&password=$${GITLAB_PASSWORD}
       EOF
 
-      export GITLAB_OAUTH_TOKEN=$(curl -k --data "@auth.txt" --request POST https://gitlab.${_DOMAIN}/oauth/token | jq -r .access_token)
+      export GITLAB_OAUTH_TOKEN=$(curl -k --data "@auth.txt" --request POST https://$${GITLAB_HOSTNAME}/oauth/token | jq -r .access_token)
 
       # Get ACM repo project ID
-      export ACM_PROJECT_ID=$(curl -k -s "https://gitlab.${_DOMAIN}/api/v4/projects?search=anthos-config-management&access_token=$${GITLAB_OAUTH_TOKEN}" | jq -r .[0].id)
+      export ACM_PROJECT_ID=$(curl -k -s "https://$${GITLAB_HOSTNAME}/api/v4/projects?search=anthos-config-management&access_token=$${GITLAB_OAUTH_TOKEN}" | jq -r .[0].id)
 
       # Get runner registration token from GitLab
-      export ACM_RUNNER_TOKEN=$(curl -k -s "https://gitlab.${_DOMAIN}/api/v4/projects/$${ACM_PROJECT_ID}?access_token=$${GITLAB_OAUTH_TOKEN}" | jq -r .runners_token)
+      export ACM_RUNNER_TOKEN=$(curl -k -s "https://$${GITLAB_HOSTNAME}/api/v4/projects/$${ACM_PROJECT_ID}?access_token=$${GITLAB_OAUTH_TOKEN}" | jq -r .runners_token)
 
       ./install_acm.sh

--- a/3_acm/outputs.tf
+++ b/3_acm/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-variable "project_id" {
-  description = "The project ID to host the cluster in"
+output "gitlab_hostname" {
+  value = data.terraform_remote_state.gitlab.outputs.gitlab_hostname
 }

--- a/3_acm/versions.tf
+++ b/3_acm/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-variable "project_id" {
-  description = "The project ID to host the cluster in"
+terraform {
+  required_version = ">= 0.12"
 }

--- a/4_demo/backend.tf
+++ b/4_demo/backend.tf
@@ -16,15 +16,15 @@
 
 terraform {
   backend "gcs" {
-    bucket  = "YOUR_PROJECT_ID-anthos-platform-tf-state"
-    prefix  = "demo"
+    bucket = "YOUR_PROJECT_ID-anthos-platform-tf-state"
+    prefix = "demo"
   }
 }
 
 data "terraform_remote_state" "gitlab" {
   backend = "gcs"
   config = {
-    bucket  = "YOUR_PROJECT_ID-anthos-platform-tf-state"
-    prefix  = "gitlab"
+    bucket = "YOUR_PROJECT_ID-anthos-platform-tf-state"
+    prefix = "gitlab"
   }
 }

--- a/4_demo/backend.tf
+++ b/4_demo/backend.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,17 @@
  * limitations under the License.
  */
 
-variable "project_id" {
-  description = "The project ID to host the cluster in"
+terraform {
+  backend "gcs" {
+    bucket  = "YOUR_PROJECT_ID-anthos-platform-tf-state"
+    prefix  = "demo"
+  }
+}
+
+data "terraform_remote_state" "gitlab" {
+  backend = "gcs"
+  config = {
+    bucket  = "YOUR_PROJECT_ID-anthos-platform-tf-state"
+    prefix  = "gitlab"
+  }
 }

--- a/4_demo/cloudbuild-destroy.yaml
+++ b/4_demo/cloudbuild-destroy.yaml
@@ -16,7 +16,6 @@ tags:
   - modern-cicd-anthos
   - modern-cicd-anthos-demo-apps
 substitutions:
-  _DOMAIN: ""
   _BUILD_IMAGES: "true"
 options:
   substitution_option: 'ALLOW_LOOSE'

--- a/4_demo/cloudbuild.yaml
+++ b/4_demo/cloudbuild.yaml
@@ -17,7 +17,6 @@ tags:
   - modern-cicd-anthos
   - modern-cicd-anthos-demo-apps
 substitutions:
-  _DOMAIN: ""
   _BUILD_IMAGES: "true"
   _APPS: "hipster-loadgenerator hipster-shop hipster-frontend petabank"
 options:
@@ -30,13 +29,19 @@ steps:
     - -c
     - |
       # TODO: Convert to gzip
+      sed -i "s/YOUR_PROJECT_ID/${PROJECT_ID}/g" backend.tf
+
       # Pull in starter-repos
       gsutil -m cp -r gs://${PROJECT_ID}-starter-repos/starter-repos .
 
+      terraform init
+      terraform apply
+
+      export GITLAB_HOSTNAME=$(terraform output gitlab_hostname)
       export GITLAB_PASSWORD=$(gcloud secrets versions access latest --secret="gitlab-password")
-      export GITLAB_HOSTNAME="gitlab.${_DOMAIN}"
       export GITLAB_TOKEN="$${GITLAB_PASSWORD}"
       export APPS="${_APPS}"
+
       git config --global user.email "anthos-platform-installer@example.com"
       git config --global user.name "Anthos Platform Installer"
 

--- a/4_demo/outputs.tf
+++ b/4_demo/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-variable "project_id" {
-  description = "The project ID to host the cluster in"
+output "gitlab_hostname" {
+  value = data.terraform_remote_state.gitlab.outputs.gitlab_hostname
 }

--- a/5_output/backend.tf
+++ b/5_output/backend.tf
@@ -16,15 +16,15 @@
 
 terraform {
   backend "gcs" {
-    bucket  = "YOUR_PROJECT_ID-anthos-platform-tf-state"
-    prefix  = "output"
+    bucket = "YOUR_PROJECT_ID-anthos-platform-tf-state"
+    prefix = "output"
   }
 }
 
 data "terraform_remote_state" "gitlab" {
   backend = "gcs"
   config = {
-    bucket  = "YOUR_PROJECT_ID-anthos-platform-tf-state"
-    prefix  = "gitlab"
+    bucket = "YOUR_PROJECT_ID-anthos-platform-tf-state"
+    prefix = "gitlab"
   }
 }

--- a/5_output/backend.tf
+++ b/5_output/backend.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,17 @@
  * limitations under the License.
  */
 
-variable "project_id" {
-  description = "The project ID to host the cluster in"
+terraform {
+  backend "gcs" {
+    bucket  = "YOUR_PROJECT_ID-anthos-platform-tf-state"
+    prefix  = "output"
+  }
+}
+
+data "terraform_remote_state" "gitlab" {
+  backend = "gcs"
+  config = {
+    bucket  = "YOUR_PROJECT_ID-anthos-platform-tf-state"
+    prefix  = "gitlab"
+  }
 }

--- a/5_output/cloudbuild-destroy.yaml
+++ b/5_output/cloudbuild-destroy.yaml
@@ -14,17 +14,12 @@
 
 tags:
   - modern-cicd-anthos
-  - modern-cicd-anthos-acm
-substitutions:
-  _BUILD_IMAGES: "true"
-options:
-  substitution_option: 'ALLOW_LOOSE'
+  - modern-cicd-anthos-output
 steps:
-# Create build-installation-image
 - name: "gcr.io/cloud-builders/gcloud"
-  id: "remove-acm"
+  id: "output"
   entrypoint: bash
   args:
     - -c
     - |
-      echo "TODO: Back out ACM but needs to be defined, this is a 'DO NOTHING' step"
+      echo "TODO: 'DO NOTHING' step for now"

--- a/5_output/cloudbuild.yaml
+++ b/5_output/cloudbuild.yaml
@@ -12,19 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+timeout: 3600s # 1hr
 tags:
   - modern-cicd-anthos
-  - modern-cicd-anthos-acm
-substitutions:
-  _BUILD_IMAGES: "true"
+  - modern-cicd-anthos-output
 options:
   substitution_option: 'ALLOW_LOOSE'
 steps:
-# Create build-installation-image
-- name: "gcr.io/cloud-builders/gcloud"
-  id: "remove-acm"
+- name: 'gcr.io/${PROJECT_ID}/anthos-platform-installer'
+  id: "output"
   entrypoint: bash
   args:
     - -c
     - |
-      echo "TODO: Back out ACM but needs to be defined, this is a 'DO NOTHING' step"
+      sed -i "s/YOUR_PROJECT_ID/${PROJECT_ID}/g" backend.tf
+
+      terraform init
+      terraform apply
+      export GITLAB_HOSTNAME=$(terraform output gitlab_hostname)
+
+      echo ""
+      echo " Log in to your GitLab instance at: https://$${GITLAB_HOSTNAME}"
+      echo " Username: root"
+      echo " To retrieve password run: \$(gcloud secrets versions access latest --secret=gitlab-password)"
+      echo " Visit the user guide in the docs (docs/index.md) to go through a user journey (add, deploy, and change applications)."

--- a/5_output/outputs.tf
+++ b/5_output/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-variable "project_id" {
-  description = "The project ID to host the cluster in"
+output "gitlab_hostname" {
+  value = data.terraform_remote_state.gitlab.outputs.gitlab_hostname
 }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In this repository we lay out a prescriptive way to create a multi-team software
 using Anthos. The platform has the following capabilities:
 
 * Allow platform administrators to create and update best practices for provisioning apps
-* Ensure App Developers can iterate independently in their own "landing zones" without interfereing with each other
+* Ensure App Developers can iterate independently in their own "landing zones" without interfering with each other
 * Allow security teams to seamlessly implement and propagate policy across the platform
 * Use GitOps for deployment
 
@@ -51,8 +51,6 @@ Within GitLab you will have the following repo structure:
 * An example [applcation repo](starter-repos/golang-template/) for a Go app
 
 ## Pre-requisites
-
-1. You must have control of a DNS domain where you can add a wildcard A record.
 
 1. Clone this repo to your local machine.
 
@@ -88,35 +86,10 @@ Within GitLab you will have the following repo structure:
     gcloud projects add-iam-policy-binding ${PROJECT_ID} --member serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com --role roles/containeranalysis.admin
     ```
 
-1. Provision the address that GitLab will use.
-
-    ```shell
-    gcloud services enable compute.googleapis.com
-    gcloud compute addresses create --region ${REGION} gitlab
-    ```
-
-1. Map your GitLab address above to your DNS by creating a wildcard DNS record.
-
-    ```shell
-    gcloud compute addresses list --filter="name=('gitlab')" --format "value(address)"
-    ```
-
-    For example if your domain is `example.org` and you want to use the
-    `platform` subdomain. You would need to create an A record that points
-    `*.platform.example.org` to the address printed in the command above.
-
-    To test that DNS is working as expected, make sure that the following command
-    returns your GitLab address:
-
-    ```shell
-    nslookup gitlab.platform.example.org
-    ```
-
 1. Run Cloud Build to create the necessary resources.
 
     ```shell
-    export DOMAIN=platform.example.org #note, do not prepend "gitlab"
-    gcloud builds submit --substitutions=_DOMAIN=${DOMAIN}
+    gcloud builds submit
     ```
 
     > :warning: This operation may take up to 30 minutes depending on region. Do not close the console or connection as the operation is NOT idempotent. If a failure occurs, [clean up](#clean-up) the environment and attempt again.
@@ -131,7 +104,7 @@ Within GitLab you will have the following repo structure:
 1. URL for Gitlab
 
     ```shell
-    echo "https://gitlab.${DOMAIN}"
+    echo "https://gitlab.endpoints.${PROJECT_ID}.cloud.goog"
     ```
 1. User and Password for GitLab are stored in the [Secrets Manager](https://cloud.google.com/secret-manager)
 
@@ -150,14 +123,14 @@ echo "Password: ${GITLAB_PASSWORD}"
 
     ```shell
     gcloud builds submit --config cloudbuild-destroy.yaml
+    gcloud endpoints services delete gitlab.endpoints.${PROJECT_ID}.cloud.goog
+    gcloud endpoints services delete registry.endpoints.${PROJECT_ID}.cloud.goog
     ```
 
 1. Unset variables (optional)
 
     ```shell
     unset PROJECT_ID
-    unset DOMAIN
-    unset SUBDOMAIN
     unset REGION
     ```
 

--- a/cloudbuild-destroy.yaml
+++ b/cloudbuild-destroy.yaml
@@ -16,7 +16,6 @@ timeout: 3600s
 tags:
   - modern-cicd-anthos
 substitutions:
-  _DOMAIN: ""
   _BUILD_IMAGES: "true"
 options:
     substitution_option: 'ALLOW_LOOSE'
@@ -51,6 +50,16 @@ steps:
   waitFor: ["-"]
 
 ## Destroy in reverse order
+#
+# 5 Output
+- name: "gcr.io/cloud-builders/gcloud"
+  id: "trigger-destroy-output"
+  dir: "5_output"
+  entrypoint: bash
+  args:
+    - -c
+    - |
+      gcloud builds submit --config=cloudbuild-destroy.yaml
 
 # 4 Apps
 - name: "gcr.io/cloud-builders/gcloud"
@@ -60,8 +69,8 @@ steps:
   args:
     - -c
     - |
-      gcloud builds submit --config=cloudbuild-destroy.yaml --substitutions="_DOMAIN=${_DOMAIN}"
-  waitFor: ["build-install-image"]
+      gcloud builds submit --config=cloudbuild-destroy.yaml
+  waitFor: ["trigger-destroy-output"]
 
 # 3 ACM
 - name: "gcr.io/cloud-builders/gcloud"
@@ -71,7 +80,7 @@ steps:
   args:
     - -c
     - |
-      gcloud builds submit --config=cloudbuild-destroy.yaml --substitutions="_DOMAIN=${_DOMAIN}"
+      gcloud builds submit --config=cloudbuild-destroy.yaml
   waitFor: ["trigger-destroy-demo-apps"]
 
 # 2 CICD
@@ -82,7 +91,7 @@ steps:
   args:
     - -c
     - |
-      gcloud builds submit --config=cloudbuild-destroy.yaml --substitutions="_DOMAIN=${_DOMAIN}"
+      gcloud builds submit --config=cloudbuild-destroy.yaml
   waitFor: ["trigger-destroy-acm"]
 
 # 1 Clusters

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,7 +16,6 @@ timeout: 7200s # 2hr
 tags:
   - modern-cicd-anthos
 substitutions:
-  _DOMAIN: ""
   _BUILD_IMAGES: "true"
   _INSTALL_APPS: "true"
 options:
@@ -39,7 +38,7 @@ steps:
   - '-c'
   - |
     gsutil mb gs://${PROJECT_ID}-starter-repos || true
-    gsutil cp -r starter-repos gs://${PROJECT_ID}-starter-repos # TODO: use -m?
+    gsutil -m cp -r starter-repos gs://${PROJECT_ID}-starter-repos
 
 # Create build-installation-image
 - name: "gcr.io/cloud-builders/gcloud"
@@ -83,12 +82,11 @@ steps:
   args:
     - -c
     - |
-      gcloud builds submit --substitutions=_DOMAIN=${_DOMAIN}
+      gcloud builds submit
   waitFor:
     - trigger-clusters
 
 # ACM
-
 - name: "gcr.io/cloud-builders/gcloud"
   id: "trigger-acm-install"
   dir: "3_acm"
@@ -96,7 +94,7 @@ steps:
   args:
     - -c
     - |
-      gcloud builds submit --substitutions=_DOMAIN=${_DOMAIN}
+      gcloud builds submit
   waitFor:
     - trigger-gitlab
 
@@ -109,23 +107,17 @@ steps:
     - -c
     - |
       [[ "${_INSTALL_APPS}" == "false" ]] && exit 0
-      gcloud builds submit --substitutions=_DOMAIN=${_DOMAIN}
+      gcloud builds submit
   waitFor:
     - trigger-acm-install
 
-- name: 'gcr.io/${PROJECT_ID}/anthos-platform-installer'
+- name: "gcr.io/cloud-builders/gcloud"
   id: "output-connect-details"
+  dir: "5_output"
   entrypoint: bash
   args:
     - -c
     - |
-      export GITLAB_HOSTNAME="gitlab.${_DOMAIN}"
-
-      echo "Log in to your GitLab instance at: https://$${GITLAB_HOSTNAME}"
-      echo "Username: root"
-      echo ""
-      echo "To retrieve password run: \$(gcloud secrets versions access latest --secret=gitlab-password)"
-      echo ""
-      echo "Visit the user guide in the docs (docs/index.md) to go through a user journey (add, deploy, and change applications)."
+      gcloud builds submit
   waitFor:
     - trigger-app-install

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -27,23 +27,9 @@ gcloud services enable cloudbuild.googleapis.com
 gcloud services enable anthos.googleapis.com
 gcloud services enable serviceusage.googleapis.com
 gcloud services enable cloudkms.googleapis.com
+gcloud services enable containeranalysis.googleapis.com
 gcloud projects add-iam-policy-binding ${PROJECT_ID} --member serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com   --role roles/owner
 gcloud projects add-iam-policy-binding ${PROJECT_ID} --member serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com   --role roles/containeranalysis.admin
 
-# Allocate GitLab Address
-gcloud services enable compute.googleapis.com
-gcloud compute addresses create --region us-central1 gitlab
-
-# Get a DNS Domain
-curl -fsSL https://claim.anthos-platform.dev/claim.sh | bash -s -- ap-${TIMESTAMP}
-export SUBDOMAIN=ap-${TIMESTAMP}
-
-# Configure DNS
-export GITLAB_ADDRESS=$(gcloud compute addresses list --filter="name=('gitlab')" --format "value(address)")
-gcloud dns record-sets transaction start --zone ${SUBDOMAIN}-zone
-gcloud dns record-sets transaction add ${GITLAB_ADDRESS} --name "*.${SUBDOMAIN}.demo.anthos-platform.dev" --type A --zone ${SUBDOMAIN}-zone --ttl 300
-gcloud dns record-sets transaction execute --zone ${SUBDOMAIN}-zone
-
 # Run Cloud Build
-export DOMAIN=${SUBDOMAIN}.demo.anthos-platform.dev
-gcloud builds submit --substitutions=_DOMAIN=${DOMAIN}
+gcloud builds submit

--- a/tests/setup_teardown.sh
+++ b/tests/setup_teardown.sh
@@ -19,8 +19,6 @@ set -e
 
 sa_creds=74668_ci-service-account
 project_id=anthos-platform-ci-env
-subdomain=ci
-domain=${subdomain}.demo.anthos-platform.dev
 
 # Set the project ID for CI
 gcloud config set project ${project_id}
@@ -40,17 +38,14 @@ gcloud auth activate-service-account --key-file=${KEY_FILE}
 # Display commands, now that creds are set.
 set -x
 
-# Make sure the project is clean before running the setup
-gcloud builds submit --config=cloudbuild-destroy.yaml --substitutions=_DOMAIN=${domain}
-
 # Deploy the platform
-gcloud builds submit --config=cloudbuild.yaml --substitutions=_DOMAIN=${domain}
+gcloud builds submit --config=cloudbuild.yaml
 
 # If the setup succeeded then tear it down.
 if [ $? -eq 0 ]; then
 	sleep 5m
 	# Clean up after the run
-	gcloud builds submit --config=cloudbuild-destroy.yaml --substitutions=_DOMAIN=${domain}
+	gcloud builds submit --config=cloudbuild-destroy.yaml
 fi
 
 echo "All passed"


### PR DESCRIPTION
This PR is to move to using Cloud Endpoints to provide DNS for GitLab in the form:

```
gitlab.endpoints.${PROJECT_ID}.cloud.goog
registry.endpoints.${PROJECT_ID}.cloud.goog
```

This removes the need to manage an external and/or third party domain.

It also introduces other more minor changes required to support this change:

- Moving to Terraform remote data sources to pass state between stages (e.g the computed GitLab hostname in this case)
- Pinning of selected module and platform versions
- Updating to use GitLab 13.x.x
- Adding a final “output” stage to decouple this from the demo app stage

One of the changes this introduces is that a top-level platform destroy operation is no longer idempotent. This should be discussed and could be added as a later enhancement.
