### PR TITLE
Pinning the cft tools container version to 0.12.0

### DIFF
--- a/test/setup/cloudbuild.yaml
+++ b/test/setup/cloudbuild.yaml
@@ -27,4 +27,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'


### PR DESCRIPTION
cft tools container image was recently upgraded to Terraform 0.13.0.  Pinning that version at 0.12.0 until we upgrade across the board.