### PR TITLE
Update ACM repo and the steps for adding new clusters

### DIFF
--- a/3_acm/config-management.yaml.tpl
+++ b/3_acm/config-management.yaml.tpl
@@ -5,9 +5,7 @@ metadata:
 spec:
   # clusterName is required and must be unique among all managed clusters
   clusterName: ${CONTEXT}
+  enableMultiRepo: true
+  enableLegacyFields: false
   policyController:
     enabled: true
-  git:
-    syncRepo: git@${GITLAB_HOSTNAME}:platform-admins/anthos-config-management.git
-    syncBranch: master
-    secretType: ssh

--- a/3_acm/install_acm.sh
+++ b/3_acm/install_acm.sh
@@ -48,9 +48,14 @@ for CONTEXT in ${CLUSTERS}; do
     GITLAB_ADDRESS=$(gcloud compute addresses describe gitlab --region us-central1 --format 'value(address)')
     export GITLAB_HOSTNAME=${GITLAB_HOSTNAME}
     export CONTEXT=${CONTEXT}
-    cat config-management.yaml.tpl | envsubst > config-management-${CONTEXT}.yaml
-    kubectl apply -f config-management-${CONTEXT}.yaml
-    rm config-management-${CONTEXT}.yaml
+    CONFIGMAGFILE=config-management-${CONTEXT}.yaml
+    cat config-management.yaml.tpl | envsubst > ${CONFIGMAGFILE}
+    kubectl apply -f ${CONFIGMAGFILE}
+    rm ${CONFIGMAGFILE}
+    ROOTSYNCFILE=root-sync-${CONTEXT}.yaml
+    cat root-sync.yaml.tpl | envsubst > ${ROOTSYNCFILE}
+    kubectl apply -f ${ROOTSYNCFILE}
+    rm ${ROOTSYNCFILE}
   # Runner is already installed, make sure the token is up to date
   # If not up to date, re-create the secret and restart the runner pod
   else

--- a/3_acm/root-sync.yaml.tpl
+++ b/3_acm/root-sync.yaml.tpl
@@ -1,0 +1,13 @@
+apiVersion: configsync.gke.io/v1alpha1
+kind: RootSync
+metadata:
+  name: root-sync
+  namespace: config-management-system
+spec:
+  sourceFormat: hierarchy
+  git:
+    repo: git@${GITLAB_HOSTNAME}:platform-admins/anthos-config-management.git
+    branch: master
+    auth: ssh
+    secretRef:
+      name: git-creds

--- a/docs/index.md
+++ b/docs/index.md
@@ -279,12 +279,32 @@ If you want to add another cluster (like asia-east1 in the above screenshots), r
    spec:
      # clusterName is required and must be unique among all managed clusters
      clusterName: $SHORT_CLUSTERNAME
-     git:
-       syncRepo: git@$GITLAB_HOSTNAME:platform-admins/anthos-config-management.git
-       syncBranch: master
-       secretType: ssh
+     enableMultiRepo: true
+     enableLegacyFields: false
      policyController:
        enabled: true
+   EOF
+   ```
+
+1. Create a Root Sync configuration for your cluster
+
+   ```shell
+   export NEW_REGION="asia-east1"
+   export SHORT_CLUSTERNAME="prod-${NEW_REGION}"
+   cat > root-sync.yaml <<EOF
+   apiVersion: configsync.gke.io/v1alpha1
+   kind: RootSync
+   metadata:
+     name: root-sync
+     namespace: config-management-system
+   spec:
+     sourceFormat: hierarchy
+     git:
+       repo: git@${GITLAB_HOSTNAME}:platform-admins/anthos-config-management.git
+       branch: master
+       auth: ssh
+       secretRef:
+         name: git-creds
    EOF
    ```
   
@@ -292,6 +312,7 @@ If you want to add another cluster (like asia-east1 in the above screenshots), r
 
     ```shell
     kubectl apply -f config-management.yaml
+    kubectl apply -f root-sync.yaml
     ```
   
 1. Check the status of the installation with the following command. Your cluster should now be synced.
@@ -408,6 +429,8 @@ If you want to add another cluster (like asia-east1 in the above screenshots), r
     git commit -m "adding $NEW_REGION"
     git push origin master
     ```
+
+<!---TODO: Update the following steps to use appctl.--->
 
 1. Add the new cluster to the Shared CI/CD configuration repo:
 

--- a/starter-repos/anthos-config-management/cluster/app-operator-role.yaml
+++ b/starter-repos/anthos-config-management/cluster/app-operator-role.yaml
@@ -1,0 +1,67 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: app-operator-role
+rules:
+  # configsync group
+  - apiGroups:
+      - configsync.gke.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  # rolebinding
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+    verbs:
+      - '*'
+  # k8s groups
+  - apiGroups:
+      - apps
+      - extensions
+    resources:
+      - daemonsets
+      - deployments
+      - deployments/finalizers
+      - ingresses
+      - replicasets
+      - statefulsets
+    verbs:
+      - '*'
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - namespaces
+      - pods
+      - persistentvolumeclaims
+      - secrets
+      - services
+      - serviceaccounts
+    verbs:
+      - '*'

--- a/starter-repos/anthos-config-management/cluster/configsync-reconciler-role.yaml
+++ b/starter-repos/anthos-config-management/cluster/configsync-reconciler-role.yaml
@@ -1,0 +1,59 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: configsync-reconciler-role
+rules:
+  # configsync group
+  - apiGroups:
+      - configsync.gke.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  # k8s groups
+  - apiGroups:
+      - apps
+      - extensions
+    resources:
+      - daemonsets
+      - deployments
+      - deployments/finalizers
+      - ingresses
+      - replicasets
+      - statefulsets
+    verbs:
+      - '*'
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - namespaces
+      - pods
+      - persistentvolumeclaims
+      - secrets
+      - services
+      - serviceaccounts
+    verbs:
+      - '*'

--- a/starter-repos/anthos-config-management/namespaces/app-environment/namespace.yaml
+++ b/starter-repos/anthos-config-management/namespaces/app-environment/namespace.yaml
@@ -1,0 +1,18 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app-environment

--- a/starter-repos/anthos-config-management/namespaces/app-environment/rolebinding.yaml
+++ b/starter-repos/anthos-config-management/namespaces/app-environment/rolebinding.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: operator
+  namespace: app-environment
+subjects:
+  - kind: User
+    name: alice-the-app-operator@foo-corp.com
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: app-operator-role

--- a/starter-repos/anthos-config-management/namespaces/managed-apps/go-app/namespace.yaml
+++ b/starter-repos/anthos-config-management/namespaces/managed-apps/go-app/namespace.yaml
@@ -1,0 +1,18 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: go-app

--- a/starter-repos/anthos-config-management/namespaces/managed-apps/go-app/rolebinding.yaml
+++ b/starter-repos/anthos-config-management/namespaces/managed-apps/go-app/rolebinding.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: operator
+  namespace: go-app
+subjects:
+  - kind: User
+    name: alice-the-app-operator@foo-corp.com
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: app-operator-role


### PR DESCRIPTION
This change uses a different approach from the one in https://github.com/GoogleCloudPlatform/solutions-modern-cicd-anthos/pull/104.

It uses the CSMR with `enableLegacyFields: false`. As a result, we need to create a `RootSync` for a new cluster.