### PR TITLE
move staging-central to staging-west

### DIFF
--- a/starter-repos/app-template/appctl/prepare.yaml
+++ b/starter-repos/app-template/appctl/prepare.yaml
@@ -45,4 +45,4 @@ prepare-manifests:
     appctl init ${APP_NAME} --app-config-repo ${APP_REPO_URL} \
     --deployment-repo ${DEPLOYMENT_REPO_URL}
   - cd ${APP_NAME}
-  - appctl prepare staging-central --from-revision=master
+  - appctl prepare staging-west --from-revision=master

--- a/starter-repos/app-template/appctl/validate.yaml
+++ b/starter-repos/app-template/appctl/validate.yaml
@@ -43,4 +43,4 @@ validate-manifests:
     appctl init ${APP_NAME} --app-config-repo ${APP_REPO_URL} \
     --deployment-repo ${DEPLOYMENT_REPO_URL}
   - cd ${APP_NAME}
-  - appctl validate staging-central --from-revision=${CI_COMMIT_BRANCH}
+  - appctl validate staging-west --from-revision=${CI_COMMIT_BRANCH}

--- a/starter-repos/app-template/config/base/patch-deployment.yaml
+++ b/starter-repos/app-template/config/base/patch-deployment.yaml
@@ -6,7 +6,8 @@ spec:
   template:
     spec:
       containers:
-      - env:
+      - name: app
+        env:
         - name: REDISHOST
           valueFrom:
             configMapKeyRef:

--- a/starter-repos/app-template/config/envs/prod-central/kustomization.yaml
+++ b/starter-repos/app-template/config/envs/prod-central/kustomization.yaml
@@ -15,7 +15,7 @@
 # Customize the namespace to be the namespace name used for prod-central environment.
 # This change should be made before `appcel env add prod-central`.
 # Once the prod-central environment is added, the namespace shouldn't be changed.
-namespace: prod-central
+namespace: go-app
 
 resources:
 - ../../base

--- a/starter-repos/app-template/config/envs/prod-east/kustomization.yaml
+++ b/starter-repos/app-template/config/envs/prod-east/kustomization.yaml
@@ -15,7 +15,7 @@
 # Customize the namespace to be the namespace name used for prod-east environment.
 # This change should be made before `appcel env add prod-east`.
 # Once the prod-east environment is added, the namespace shouldn't be changed.
-namespace: prod-east
+namespace: go-app
 
 resources:
 - ../../base

--- a/starter-repos/app-template/config/envs/staging-west/deployment.yaml
+++ b/starter-repos/app-template/config/envs/staging-west/deployment.yaml
@@ -14,4 +14,4 @@ spec:
         image: app
         env:
         - name: ENVIRONMENT
-          value: staging-cental
+          value: staging-west

--- a/starter-repos/app-template/config/envs/staging-west/kustomization.yaml
+++ b/starter-repos/app-template/config/envs/staging-west/kustomization.yaml
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Customize the namespace to be the namespace name used for staging-central environment.
-# This change should be made before `appcel env add staging-cental`.
-# Once the staging-cental environment is added, the namespace shouldn't be changed.
-namespace: staging-central
+# Customize the namespace to be the namespace name used for staging-west environment.
+# This change should be made before `appcel env add staging-west`.
+# Once the staging-west environment is added, the namespace shouldn't be changed.
+namespace: go-app
 
 resources:
 - ../../base

--- a/starter-repos/app-template/skaffold-ci.yaml
+++ b/starter-repos/app-template/skaffold-ci.yaml
@@ -9,15 +9,15 @@ profiles:
       cluster:
         dockerConfig:
           path: ~/.docker/config.json          
-  # Profile to render "staging-central" manifest.
+  # Profile to render "staging-west" manifest.
   # It is only aimed to add the image digest but not generates the fully
   # hydrated config. So the `--validate` flag of kubectl should be
   # disabled (disableValidation=true) and should not use kustomize deployer.
-  - name: staging-central
+  - name: staging-west
     deploy:
       kubectl:
         manifests:
-        - config/envs/staging-central/deployment.yaml
+        - config/envs/staging-west/deployment.yaml
         flags:
           disableValidation: true
   # Profile to render "prod-central" manifest.

--- a/starter-repos/app-template/skaffold/render.yaml
+++ b/starter-repos/app-template/skaffold/render.yaml
@@ -30,10 +30,10 @@ skaffold-render:
     - export SKAFFOLD_LOUD=true
     - export SKAFFOLD_TAG=${CI_COMMIT_SHA}
     # The `skaffold render` tags the new image with the actual digest.
-    - skaffold render --filename=skaffold-ci.yaml --add-skaffold-labels=false --digest-source=remote -p staging-central --output /tmp/staging-central-deployment.yaml
+    - skaffold render --filename=skaffold-ci.yaml --add-skaffold-labels=false --digest-source=remote -p staging-west --output /tmp/staging-west-deployment.yaml
     - skaffold render --filename=skaffold-ci.yaml --add-skaffold-labels=false --digest-source=remote -p prod-central --output /tmp/prod-central-deployment.yaml
     - skaffold render --filename=skaffold-ci.yaml --add-skaffold-labels=false --digest-source=remote -p prod-east --output /tmp/prod-east-deployment.yaml
-    - cp /tmp/staging-central-deployment.yaml config/envs/staging-central/deployment.yaml
+    - cp /tmp/staging-west-deployment.yaml config/envs/staging-west/deployment.yaml
     - cp /tmp/prod-central-deployment.yaml config/envs/prod-central/deployment.yaml
     - cp /tmp/prod-east-deployment.yaml config/envs/prod-east/deployment.yaml
   artifacts:


### PR DESCRIPTION
- Since the staging cluster created is in us-west. So I moved the environment to staging-west.
- Updated the namespace to `go-app`, which is managed by the root repo.
- Fixed a bug in the deployment patch file.