### PR TITLE
Pass the env-namespace in the validate/prepare stage

### DIFF
--- a/starter-repos/app-template/appctl/prepare.yaml
+++ b/starter-repos/app-template/appctl/prepare.yaml
@@ -43,6 +43,6 @@ prepare-manifests:
   - git config --global user.name ${CI_PROJECT_NAMESPACE}/${CI_PROJECT_NAME}
   - |
     appctl init ${APP_NAME} --app-config-repo ${APP_REPO_URL} \
-    --deployment-repo ${DEPLOYMENT_REPO_URL}
+    --deployment-repo ${DEPLOYMENT_REPO_URL} --env-namespace app-environment
   - cd ${APP_NAME}
   - appctl prepare staging-west --from-revision=master

--- a/starter-repos/app-template/appctl/validate.yaml
+++ b/starter-repos/app-template/appctl/validate.yaml
@@ -41,6 +41,6 @@ validate-manifests:
   - git config --global user.name ${CI_PROJECT_NAMESPACE}/${CI_PROJECT_NAME}
   - |
     appctl init ${APP_NAME} --app-config-repo ${APP_REPO_URL} \
-    --deployment-repo ${DEPLOYMENT_REPO_URL}
+    --deployment-repo ${DEPLOYMENT_REPO_URL} --env-namespace app-environment
   - cd ${APP_NAME}
   - appctl validate staging-west --from-revision=${CI_COMMIT_BRANCH}


### PR DESCRIPTION
The pipeline runs `appctl init` to get the appctl configuration of the
pre-initialized application. It will use the environment namespace
defined in the appctl configuration file for hydration.