### PR TITLE
A workaround to avoid skaffold attaching image digest at the tail. 

### DIFF
--- a/starter-repos/app-template/skaffold-ci.yaml
+++ b/starter-repos/app-template/skaffold-ci.yaml
@@ -2,7 +2,6 @@ apiVersion: skaffold/v2beta7
 kind: Config
 metadata:
   name: app-template
-# Profile.build depends on the top-tier build "artifacts".
 build:
   artifacts:
   - image: app
@@ -11,8 +10,19 @@ profiles:
   - name: ci
     build:
       cluster:
+        # Note: `skaffold build` may fail with
+        # 'secrets "docker-cfg" already exists' error.
+        # If that happens, do not use "dockerConfig 1"
+        # but "dockerConfig 2" as a workaround.
+
+        # dockerConfig 1
         dockerConfig:
-          path: ~/.docker/config.json          
+          path: ~/.docker/config.json
+
+        # # dockerConfig 2
+        # dockerConfig:
+        #   secretName: docker-cfg
+
   # Profile to render "staging-west" manifest.
   # It is only aimed to add the image digest but not generates the fully
   # hydrated config. So the `--validate` flag of kubectl should be

--- a/starter-repos/app-template/skaffold/render.yaml
+++ b/starter-repos/app-template/skaffold/render.yaml
@@ -14,7 +14,7 @@
 
 # Different from the render in ../shared-ci-cd/skaffold/render.yaml,
 # this skaffold-render updates the *DRY* config with the new skaffold image and
-# do not hydrate the resources. The resource hydration is done via `appctl prepare`  
+# do not hydrate the resources. The resource hydration is done via `appctl prepare`
 skaffold-render:
   stage: render-manifests
   image: gcr.io/k8s-skaffold/skaffold:v1.14.0
@@ -35,6 +35,10 @@ skaffold-render:
     - git config --global user.email "${CI_PROJECT_NAME}-ci@${CI_SERVER_HOST}"
     - git config --global user.name "${CI_PROJECT_NAMESPACE}/${CI_PROJECT_NAME}"
 
+    - |
+      sed -i "s/image:.*/image: app/g" config/envs/prod-central/deployment.yaml
+      sed -i "s/image:.*/image: app/g" config/envs/prod-east/deployment.yaml
+      sed -i "s/image:.*/image: app/g" config/envs/staging-west/deployment.yaml
     # Setup environment
     - export SKAFFOLD_DEFAULT_REPO=${GCP_AR_REPO}
     - export SKAFFOLD_LOUD=true
@@ -56,5 +60,3 @@ skaffold-render:
         git commit -m "[${CI_COMMIT_SHA:0:7}] update built manfiests"
         git push origin HEAD:${CI_COMMIT_REF_NAME}
       fi
-
-


### PR DESCRIPTION
1. Always reset the image without digest before running skaffold render.
2. Provide a solution to resolve the skaffold "docker-cfg" error.  

See output https://screenshot.googleplex.com/9uCpnfYmFnZqxTg.png