### PR TITLE
Adding commands to enable Binary Authorization and Secrets Manager to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,10 @@ Within GitLab you will have the following repo structure:
     gcloud services enable cloudbuild.googleapis.com
     gcloud services enable anthos.googleapis.com
     gcloud services enable serviceusage.googleapis.com
+    gcloud services enable binaryauthorization.googleapis.com
     gcloud services enable cloudkms.googleapis.com
     gcloud services enable containeranalysis.googleapis.com
+    gcloud services enable secretmanager.googleapis.com
     gcloud projects add-iam-policy-binding ${PROJECT_ID} --member serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com --role roles/owner
     gcloud projects add-iam-policy-binding ${PROJECT_ID} --member serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com --role roles/containeranalysis.admin
     ```

--- a/test/install.sh
+++ b/test/install.sh
@@ -26,8 +26,10 @@ export PROJECT_NUMBER=$(gcloud projects describe ${PROJECT_ID} --format 'value(p
 gcloud services enable cloudbuild.googleapis.com
 gcloud services enable anthos.googleapis.com
 gcloud services enable serviceusage.googleapis.com
+gcloud services enable binaryauthorization.googleapis.com
 gcloud services enable cloudkms.googleapis.com
 gcloud services enable containeranalysis.googleapis.com
+gcloud services enable secretmanager.googleapis.com
 gcloud projects add-iam-policy-binding ${PROJECT_ID} --member serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com   --role roles/owner
 gcloud projects add-iam-policy-binding ${PROJECT_ID} --member serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com   --role roles/containeranalysis.admin
 


### PR DESCRIPTION
Since Terraform is already trying to enable the APIs but there is a timing issue, I've added the gcloud commands to enable them before running the setup scripts.  This should help to reduce the likelihood of hitting the Secrets Manager API not enabled error condition (Issue #127).

