### PR TITLE
Include enabling Secret Manager API in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Within GitLab you will have the following repo structure:
     gcloud services enable serviceusage.googleapis.com
     gcloud services enable cloudkms.googleapis.com
     gcloud services enable containeranalysis.googleapis.com
+    gcloud services enable secretmanager.googleapis.com
     gcloud projects add-iam-policy-binding ${PROJECT_ID} --member serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com --role roles/owner
     gcloud projects add-iam-policy-binding ${PROJECT_ID} --member serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com --role roles/containeranalysis.admin
     ```


### PR DESCRIPTION
Cloud Build failed to complete project setup without Secret Manager enabled.