### PR TITLE
Updating the golang template for new module requirements.

### DIFF
--- a/starter-repos/golang-template/Dockerfile
+++ b/starter-repos/golang-template/Dockerfile
@@ -15,5 +15,6 @@
 FROM golang:1
 WORKDIR /app
 COPY *.go ./
+COPY go.mod ./
 RUN go build -o golang-template
 CMD ["/app/golang-template"]

--- a/starter-repos/golang-template/go.mod
+++ b/starter-repos/golang-template/go.mod
@@ -1,0 +1,3 @@
+module example.com/m
+
+go 1.16


### PR DESCRIPTION
In the current version of Golang a go.mod is expected.  Adding a go.mod to the starter repo, so the starter is still a functioning application.  Going forward application teams would then be responsible for keeping their individual go.mod files current and up to date.